### PR TITLE
deps: upgrade lowdb to 5.0.5

### DIFF
--- a/core/database/index.ts
+++ b/core/database/index.ts
@@ -1,4 +1,5 @@
-import { Low, JSONFile } from "lowdb";
+import { Low } from "lowdb";
+import { JSONFile } from "lowdb/node";
 import type { Address, ContractDetails } from "core/types";
 
 type Data = {

--- a/lowdb.d.ts
+++ b/lowdb.d.ts
@@ -1,0 +1,7 @@
+declare module "lowdb" {
+  export * from "lowdb/lib";
+}
+
+declare module "lowdb/node" {
+  export * from "lowdb/lib/node";
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rainbow-me/rainbowkit": "^0.8.1",
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",
-    "lowdb": "4.0.0",
+    "lowdb": "5.0.5",
     "next": "^13.0.7",
     "next-themes": "^0.2.1",
     "react": "^18.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,10 +4895,10 @@ loupe@^2.3.1:
   dependencies:
     get-func-name "^2.0.0"
 
-lowdb@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lowdb/-/lowdb-4.0.0.tgz#177bc8ce5b0110248cc61a402faf9a51ce62bc11"
-  integrity sha512-wH4WPH2A+doyzd9mluhMQQsdrHNfOXJE5+C5N03QvH+8EoEMB1WWnjkfn1MkPtVdDrONRTojuNAWi6Es3rVtmA==
+lowdb@5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/lowdb/-/lowdb-5.0.5.tgz#30315e5a42432df188dcd17f1e5a288de68848e8"
+  integrity sha512-7EWKmIMhNKA8TXFhL8t0p6N2LC53l3ZqsWQGSksGhhjrcms9rbKlyrAh2PzSGK5v0KPJ2W5VItBnC3NDRzOnzQ==
   dependencies:
     steno "^3.0.0"
 


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

- Upgrade `lowdb` to 5.0.5
- Resolve type import issues