### PR TITLE
refactor: replace react import with named imports

### DIFF
--- a/components/contract/manager/index.tsx
+++ b/components/contract/manager/index.tsx
@@ -5,7 +5,12 @@ import {
 import Anchor from "components/anchor";
 import Field from "components/field";
 import { useContracts } from "hooks";
-import { ButtonHTMLAttributes, DetailedHTMLProps, useState } from "react";
+import {
+  ButtonHTMLAttributes,
+  ChangeEvent,
+  DetailedHTMLProps,
+  useState,
+} from "react";
 
 type IconButtonProps = DetailedHTMLProps<
   ButtonHTMLAttributes<HTMLButtonElement>,
@@ -27,7 +32,7 @@ const Manager = () => {
   const [address, setAddress] = useState("");
   const { mutate } = useContracts();
 
-  const handleAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
     setAddress(event.target.value);
   };
 

--- a/components/contract/setup/index.tsx
+++ b/components/contract/setup/index.tsx
@@ -1,7 +1,7 @@
 import { Square2StackIcon } from "@heroicons/react/24/outline";
 import Anchor from "components/anchor";
 import Field from "components/field";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 
 const Setup = () => {
   const [focusedInput, setFocusedInput] = useState("");
@@ -16,27 +16,23 @@ const Setup = () => {
   );
   const command = `forge create ${path}:${contractName} --verify --unlocked --from ${deployerAddress} --rpc-url ${rpcUrl} --verifier-url ${verifierUrl} --etherscan-api-key blacksmith`;
 
-  const handleAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
     setDeployerAddress(event.target.value);
   };
 
-  const handlePathChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handlePathChange = (event: ChangeEvent<HTMLInputElement>) => {
     setPath(event.target.value);
   };
 
-  const handleContractNameChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  const handleContractNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setContractName(event.target.value);
   };
 
-  const handleRpcUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRpcUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
     setRpcUrl(event.target.value);
   };
 
-  const handleVerifierUrlChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  const handleVerifierUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
     setVerifierUrl(event.target.value);
   };
 

--- a/components/field/index.tsx
+++ b/components/field/index.tsx
@@ -1,8 +1,10 @@
-type FieldProps = React.DetailedHTMLProps<
-  React.InputHTMLAttributes<HTMLInputElement>,
+import { ChangeEvent, DetailedHTMLProps, InputHTMLAttributes } from "react";
+
+type FieldProps = DetailedHTMLProps<
+  InputHTMLAttributes<HTMLInputElement>,
   HTMLInputElement
 > & {
-  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleChange: (event: ChangeEvent<HTMLInputElement>) => void;
   id: string;
   inputName: string;
   type: string;

--- a/components/functions/index.test.tsx
+++ b/components/functions/index.test.tsx
@@ -1,3 +1,4 @@
+import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAbiDefinedFunctionList, buildAddress } from "testing/factory";
 import { useContractRead, useContractWrite } from "wagmi";
@@ -18,7 +19,7 @@ const useContractWriteMock = useContractWrite as jest.Mock<any>;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
 const renderFunctions = (
-  props: Partial<React.ComponentProps<typeof Functions>> = {}
+  props: Partial<ComponentProps<typeof Functions>> = {}
 ) => {
   return render(
     <Functions

--- a/components/inputs/index.tsx
+++ b/components/inputs/index.tsx
@@ -1,6 +1,7 @@
 import Button from "components/button";
 import Field from "components/field";
 import { Arg } from "core/types";
+import { ChangeEvent } from "react";
 
 type InputsProps = {
   args: readonly Arg[];
@@ -98,7 +99,7 @@ const Inputs = ({
           );
         }
 
-        const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
           updateValue([...keys, index], event.target.value);
         };
 

--- a/components/wallet/transfer/index.tsx
+++ b/components/wallet/transfer/index.tsx
@@ -2,7 +2,7 @@ import Button from "components/button";
 import Field from "components/field";
 import Listbox from "components/listbox";
 import { useEther } from "hooks";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { usePrepareSendTransaction, useSendTransaction } from "wagmi";
 
 const Transfer = () => {
@@ -15,9 +15,7 @@ const Transfer = () => {
   });
   const { sendTransaction } = useSendTransaction(config);
 
-  const handleRecipientChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  const handleRecipientChange = (event: ChangeEvent<HTMLInputElement>) => {
     setRecipient(event.target.value);
   };
 


### PR DESCRIPTION
## Motivation

Prefer named imports from `React` submodules.

## Solution

Replace all inline usage of `React.*`