### PR TITLE
refactor: use named exports

### DIFF
--- a/__tests__/pages/api/contracts/[address].test.ts
+++ b/__tests__/pages/api/contracts/[address].test.ts
@@ -1,4 +1,4 @@
-import contract from "core/contract";
+import { contract } from "core/contract";
 import { getAddress } from "core/utils";
 import { server } from "mocks/server";
 import { rest } from "msw";

--- a/__tests__/pages/api/contracts/index.test.ts
+++ b/__tests__/pages/api/contracts/index.test.ts
@@ -1,4 +1,4 @@
-import contract from "core/contract";
+import { contract } from "core/contract";
 import { createMocks } from "node-mocks-http";
 import contractsHandler from "pages/api/contracts";
 

--- a/components/anchor/index.tsx
+++ b/components/anchor/index.tsx
@@ -5,7 +5,7 @@ type AnchorProps = DetailedHTMLProps<
   HTMLAnchorElement
 >;
 
-const Anchor = (props: AnchorProps) => (
+export const Anchor = (props: AnchorProps) => (
   <a
     {...props}
     className="underline focus:bg-black focus:text-white dark:focus:bg-white dark:focus:text-black focus:outline-none"
@@ -13,5 +13,3 @@ const Anchor = (props: AnchorProps) => (
     {props.children}
   </a>
 );
-
-export default Anchor;

--- a/components/balance/index.test.tsx
+++ b/components/balance/index.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
 import type { Mock } from "vitest";
 import { useBalance } from "wagmi";
-import Balance from ".";
+import { Balance } from ".";
 
 vi.mock("wagmi");
 

--- a/components/balance/index.tsx
+++ b/components/balance/index.tsx
@@ -5,7 +5,7 @@ type BalanceProps = {
   address: Address;
 };
 
-const Balance = ({ address }: BalanceProps) => {
+export const Balance = ({ address }: BalanceProps) => {
   const { data, isError, isLoading } = useBalance({ address, watch: true });
 
   if (isLoading) return <div>loading...</div>;
@@ -16,5 +16,3 @@ const Balance = ({ address }: BalanceProps) => {
     </div>
   );
 };
-
-export default Balance;

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -3,7 +3,7 @@ import { ButtonHTMLAttributes, PropsWithChildren } from "react";
 type ButtonProps = PropsWithChildren<{}> &
   ButtonHTMLAttributes<HTMLButtonElement>;
 
-const Button = ({ children, ...props }: ButtonProps) => {
+export const Button = ({ children, ...props }: ButtonProps) => {
   return (
     <button
       className="self-start border border-black dark:border-white px-2 py-0.5 text-sm disabled:cursor-not-allowed disabled:opacity-50 hover:bg-slate-200 focus:bg-slate-200 dark:hover:bg-white dark:hover:text-black dark:focus:bg-white dark:focus:text-black focus:outline-none"
@@ -13,5 +13,3 @@ const Button = ({ children, ...props }: ButtonProps) => {
     </button>
   );
 };
-
-export default Button;

--- a/components/connect/index.tsx
+++ b/components/connect/index.tsx
@@ -1,6 +1,6 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 
-const Connect = () => {
+export const Connect = () => {
   return (
     <ConnectButton.Custom>
       {({
@@ -77,5 +77,3 @@ const Connect = () => {
     </ConnectButton.Custom>
   );
 };
-
-export default Connect;

--- a/components/contract/index.test.tsx
+++ b/components/contract/index.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "testing/factory";
 import type { Mock } from "vitest";
 import { useBalance, useContractRead, useContractWrite } from "wagmi";
-import Contract from ".";
+import { Contract } from ".";
 
 vi.mock("wagmi");
 

--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -4,7 +4,7 @@ import Functions from "components/functions";
 import { Abi, AbiDefinedFunction, Address } from "core/types";
 import { ethers } from "ethers";
 import { useContracts } from "hooks";
-import Manager from "./manager";
+import { Manager } from "./manager";
 import Setup from "./setup";
 
 const filterDefinedFunctions = (abi: Abi): AbiDefinedFunction[] => {

--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -1,5 +1,5 @@
 import { Square2StackIcon } from "@heroicons/react/24/outline";
-import Balance from "components/balance";
+import { Balance } from "components/balance";
 import Functions from "components/functions";
 import { Abi, AbiDefinedFunction, Address } from "core/types";
 import { ethers } from "ethers";

--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -5,7 +5,7 @@ import { Abi, AbiDefinedFunction, Address } from "core/types";
 import { ethers } from "ethers";
 import { useContracts } from "hooks";
 import { Manager } from "./manager";
-import Setup from "./setup";
+import { Setup } from "./setup";
 
 const filterDefinedFunctions = (abi: Abi): AbiDefinedFunction[] => {
   return abi.filter(({ type }) => type === "function") as AbiDefinedFunction[];

--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -18,7 +18,7 @@ const Introduction = () => (
   </div>
 );
 
-const Contract = ({ address }: { address: Address }) => {
+export const Contract = ({ address }: { address: Address }) => {
   const { contracts, isLoading, isError } = useContracts();
 
   if (isLoading) return <div>loading...</div>;
@@ -67,5 +67,3 @@ const Contract = ({ address }: { address: Address }) => {
     </section>
   );
 };
-
-export default Contract;

--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -1,6 +1,6 @@
 import { Square2StackIcon } from "@heroicons/react/24/outline";
 import { Balance } from "components/balance";
-import Functions from "components/functions";
+import { Functions } from "components/functions";
 import { Abi, AbiDefinedFunction, Address } from "core/types";
 import { ethers } from "ethers";
 import { useContracts } from "hooks";

--- a/components/contract/manager/index.test.tsx
+++ b/components/contract/manager/index.test.tsx
@@ -2,7 +2,7 @@ import { server } from "mocks/server";
 import { rest } from "msw";
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
-import Manager from ".";
+import { Manager } from ".";
 
 describe("Manager", () => {
   it("should handle contract imports", async () => {

--- a/components/contract/manager/index.tsx
+++ b/components/contract/manager/index.tsx
@@ -3,7 +3,7 @@ import {
   PlusSmallIcon,
 } from "@heroicons/react/24/outline";
 import { Anchor } from "components/anchor";
-import Field from "components/field";
+import { Field } from "components/field";
 import { useContracts } from "hooks";
 import {
   ButtonHTMLAttributes,

--- a/components/contract/manager/index.tsx
+++ b/components/contract/manager/index.tsx
@@ -26,7 +26,7 @@ const IconButton = (props: IconButtonProps) => (
   </button>
 );
 
-const Manager = () => {
+export const Manager = () => {
   const [response, setResponse] = useState("");
   const [deleteAllResponse, setDeleteAllResponse] = useState("");
   const [address, setAddress] = useState("");
@@ -116,5 +116,3 @@ const Manager = () => {
     </div>
   );
 };
-
-export default Manager;

--- a/components/contract/manager/index.tsx
+++ b/components/contract/manager/index.tsx
@@ -2,7 +2,7 @@ import {
   ArchiveBoxXMarkIcon,
   PlusSmallIcon,
 } from "@heroicons/react/24/outline";
-import Anchor from "components/anchor";
+import { Anchor } from "components/anchor";
 import Field from "components/field";
 import { useContracts } from "hooks";
 import {

--- a/components/contract/setup/index.test.tsx
+++ b/components/contract/setup/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
-import Setup from ".";
+import { Setup } from ".";
 
 describe("Setup", () => {
   it("renders the default command", () => {

--- a/components/contract/setup/index.tsx
+++ b/components/contract/setup/index.tsx
@@ -1,6 +1,6 @@
 import { Square2StackIcon } from "@heroicons/react/24/outline";
 import { Anchor } from "components/anchor";
-import Field from "components/field";
+import { Field } from "components/field";
 import { ChangeEvent, useState } from "react";
 
 export const Setup = () => {

--- a/components/contract/setup/index.tsx
+++ b/components/contract/setup/index.tsx
@@ -3,7 +3,7 @@ import { Anchor } from "components/anchor";
 import Field from "components/field";
 import { ChangeEvent, useState } from "react";
 
-const Setup = () => {
+export const Setup = () => {
   const [focusedInput, setFocusedInput] = useState("");
   const [deployerAddress, setDeployerAddress] = useState<string>(
     "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
@@ -169,5 +169,3 @@ const Setup = () => {
     </div>
   );
 };
-
-export default Setup;

--- a/components/contract/setup/index.tsx
+++ b/components/contract/setup/index.tsx
@@ -1,5 +1,5 @@
 import { Square2StackIcon } from "@heroicons/react/24/outline";
-import Anchor from "components/anchor";
+import { Anchor } from "components/anchor";
 import Field from "components/field";
 import { ChangeEvent, useState } from "react";
 

--- a/components/contracts/index.test.tsx
+++ b/components/contracts/index.test.tsx
@@ -4,7 +4,7 @@ import { rest } from "msw";
 import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildContractDetailsList } from "testing/factory";
-import Contracts from ".";
+import { Contracts } from ".";
 
 const renderContracts = (
   props: Partial<ComponentProps<typeof Contracts>> = {}

--- a/components/contracts/index.tsx
+++ b/components/contracts/index.tsx
@@ -6,7 +6,10 @@ type ContractsProps = {
   setActiveContract(address: Address): void;
 };
 
-const Contracts = ({ activeContract, setActiveContract }: ContractsProps) => {
+export const Contracts = ({
+  activeContract,
+  setActiveContract,
+}: ContractsProps) => {
   const { contracts, isLoading, isError } = useContracts();
 
   if (isLoading) return <div className="flex-grow">loading...</div>;
@@ -30,5 +33,3 @@ const Contracts = ({ activeContract, setActiveContract }: ContractsProps) => {
     </ul>
   );
 };
-
-export default Contracts;

--- a/components/field/index.test.tsx
+++ b/components/field/index.test.tsx
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { ComponentProps } from "react";
 import { render, screen } from "testing";
-import Field from ".";
+import { Field } from ".";
 
 const renderField = (props: Partial<ComponentProps<typeof Field>> = {}) => {
   return render(

--- a/components/field/index.tsx
+++ b/components/field/index.tsx
@@ -11,7 +11,7 @@ type FieldProps = DetailedHTMLProps<
   value: string;
 };
 
-const Field = ({
+export const Field = ({
   inputName,
   disabled,
   value,
@@ -48,5 +48,3 @@ const Field = ({
     </li>
   );
 };
-
-export default Field;

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -1,5 +1,5 @@
 import { Anchor } from "components/anchor";
-import Switch from "components/switch";
+import { Switch } from "components/switch";
 
 export const Footer = () => (
   <footer className="flex flex-col">

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -1,7 +1,7 @@
 import { Anchor } from "components/anchor";
 import Switch from "components/switch";
 
-const Footer = () => (
+export const Footer = () => (
   <footer className="flex flex-col">
     <Switch />
     <div className="text-sm px-1.5">
@@ -20,5 +20,3 @@ const Footer = () => (
     </div>
   </footer>
 );
-
-export default Footer;

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -1,4 +1,4 @@
-import Anchor from "components/anchor";
+import { Anchor } from "components/anchor";
 import Switch from "components/switch";
 
 const Footer = () => (

--- a/components/function/container/index.tsx
+++ b/components/function/container/index.tsx
@@ -2,8 +2,6 @@ import { PropsWithChildren } from "react";
 
 type ContainerProps = PropsWithChildren<{}>;
 
-const Container = ({ children }: ContainerProps) => {
+export const Container = ({ children }: ContainerProps) => {
   return <section className="flex items-center gap-1">{children}</section>;
 };
-
-export default Container;

--- a/components/function/index.test.tsx
+++ b/components/function/index.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "testing";
 import { buildAbiDefinedFunction, buildAddress } from "testing/factory";
 import type { Mock } from "vitest";
 import { useContractRead, useContractWrite } from "wagmi";
-import Function from ".";
+import { Function } from ".";
 
 vi.mock("wagmi");
 

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -2,7 +2,7 @@ import { AbiDefinedFunction, Address } from "core/types";
 import { Nonpayable } from "./nonpayable";
 import { Payable } from "./payable";
 import { Pure } from "./pure";
-import View from "./view";
+import { View } from "./view";
 
 type FunctionProps = {
   address: Address;

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -1,7 +1,7 @@
 import { AbiDefinedFunction, Address } from "core/types";
 import { Nonpayable } from "./nonpayable";
 import { Payable } from "./payable";
-import Pure from "./pure";
+import { Pure } from "./pure";
 import View from "./view";
 
 type FunctionProps = {

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -1,5 +1,5 @@
 import { AbiDefinedFunction, Address } from "core/types";
-import Nonpayable from "./nonpayable";
+import { Nonpayable } from "./nonpayable";
 import Payable from "./payable";
 import Pure from "./pure";
 import View from "./view";

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -1,6 +1,6 @@
 import { AbiDefinedFunction, Address } from "core/types";
 import { Nonpayable } from "./nonpayable";
-import Payable from "./payable";
+import { Payable } from "./payable";
 import Pure from "./pure";
 import View from "./view";
 

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -9,7 +9,7 @@ type FunctionProps = {
   func: AbiDefinedFunction;
 };
 
-const Function = ({ address, func }: FunctionProps) => {
+export const Function = ({ address, func }: FunctionProps) => {
   switch (func.stateMutability) {
     case "pure":
       return <Pure address={address} func={func} />;
@@ -21,5 +21,3 @@ const Function = ({ address, func }: FunctionProps) => {
       return <Payable address={address} func={func} />;
   }
 };
-
-export default Function;

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "testing/factory";
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
-import Nonpayable from ".";
+import { Nonpayable } from ".";
 
 vi.mock("wagmi");
 

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useArgs } from "hooks";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
-import Output from "../output";
+import { Output } from "../output";
 import Signature from "../signature";
 
 type NonpayableProps = {

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -9,7 +9,7 @@ import { useArgs } from "hooks";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
-import Signature from "../signature";
+import { Signature } from "../signature";
 
 type NonpayableProps = {
   address: Address;

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/button";
-import Inputs from "components/inputs";
+import { Inputs } from "components/inputs";
 import {
   AbiDefinedFunction,
   AbiParameterWithComponents,

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -1,4 +1,4 @@
-import Button from "components/button";
+import { Button } from "components/button";
 import Inputs from "components/inputs";
 import {
   AbiDefinedFunction,

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "core/types";
 import { useArgs } from "hooks";
 import { useContractWrite } from "wagmi";
-import Container from "../container";
+import { Container } from "../container";
 import Output from "../output";
 import Signature from "../signature";
 

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -16,7 +16,7 @@ type NonpayableProps = {
   func: AbiDefinedFunction;
 };
 
-const Nonpayable = ({ address, func }: NonpayableProps) => {
+export const Nonpayable = ({ address, func }: NonpayableProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -51,5 +51,3 @@ const Nonpayable = ({ address, func }: NonpayableProps) => {
     </li>
   );
 };
-
-export default Nonpayable;

--- a/components/function/output/index.test.tsx
+++ b/components/function/output/index.test.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildResult } from "testing/factory";
-import Output from ".";
+import { Output } from ".";
 
 const renderOutput = (props: Partial<ComponentProps<typeof Output>> = {}) =>
   render(

--- a/components/function/output/index.tsx
+++ b/components/function/output/index.tsx
@@ -13,7 +13,7 @@ const formatData = (data: any | undefined): string => {
   return data.toString();
 };
 
-const Output = ({
+export const Output = ({
   data,
   isTouched,
   isLoading,
@@ -27,5 +27,3 @@ const Output = ({
     );
   return <span>{formatData(data)}</span>;
 };
-
-export default Output;

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "testing/factory";
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
-import Payable from ".";
+import { Payable } from ".";
 
 vi.mock("wagmi");
 

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -18,7 +18,7 @@ type PayableProps = {
   func: AbiDefinedFunction;
 };
 
-const Payable = ({ address, func }: PayableProps) => {
+export const Payable = ({ address, func }: PayableProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -75,5 +75,3 @@ const Payable = ({ address, func }: PayableProps) => {
     </li>
   );
 };
-
-export default Payable;

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useArgs, useEther } from "hooks";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
-import Output from "../output";
+import { Output } from "../output";
 import Signature from "../signature";
 
 type PayableProps = {

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "components/button";
 import { Field } from "components/field";
 import { Inputs } from "components/inputs";
-import Listbox from "components/listbox";
+import { Listbox } from "components/listbox";
 import {
   AbiDefinedFunction,
   AbiParameterWithComponents,

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -11,7 +11,7 @@ import { useArgs, useEther } from "hooks";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
-import Signature from "../signature";
+import { Signature } from "../signature";
 
 type PayableProps = {
   address: Address;

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/button";
 import { Field } from "components/field";
-import Inputs from "components/inputs";
+import { Inputs } from "components/inputs";
 import Listbox from "components/listbox";
 import {
   AbiDefinedFunction,

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -1,4 +1,4 @@
-import Button from "components/button";
+import { Button } from "components/button";
 import Field from "components/field";
 import Inputs from "components/inputs";
 import Listbox from "components/listbox";

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/button";
-import Field from "components/field";
+import { Field } from "components/field";
 import Inputs from "components/inputs";
 import Listbox from "components/listbox";
 import {

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "core/types";
 import { useArgs, useEther } from "hooks";
 import { useContractWrite } from "wagmi";
-import Container from "../container";
+import { Container } from "../container";
 import Output from "../output";
 import Signature from "../signature";
 

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "testing/factory";
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
-import Pure from ".";
+import { Pure } from ".";
 
 vi.mock("wagmi");
 

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -16,7 +16,7 @@ type PureProps = {
   func: AbiDefinedFunction;
 };
 
-const Pure = ({ address, func }: PureProps) => {
+export const Pure = ({ address, func }: PureProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -45,5 +45,3 @@ const Pure = ({ address, func }: PureProps) => {
     </li>
   );
 };
-
-export default Pure;

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/button";
-import Inputs from "components/inputs";
+import { Inputs } from "components/inputs";
 import {
   AbiDefinedFunction,
   AbiParameterWithComponents,

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -9,7 +9,7 @@ import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
-import Signature from "../signature";
+import { Signature } from "../signature";
 
 type PureProps = {
   address: Address;

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -1,4 +1,4 @@
-import Button from "components/button";
+import { Button } from "components/button";
 import Inputs from "components/inputs";
 import {
   AbiDefinedFunction,

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "core/types";
 import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
-import Container from "../container";
+import { Container } from "../container";
 import Output from "../output";
 import Signature from "../signature";
 

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
-import Output from "../output";
+import { Output } from "../output";
 import Signature from "../signature";
 
 type PureProps = {

--- a/components/function/signature/index.test.tsx
+++ b/components/function/signature/index.test.tsx
@@ -5,7 +5,7 @@ import {
   buildOutput,
   buildOutputList,
 } from "testing/factory";
-import Signature from ".";
+import { Signature } from ".";
 
 describe("Signature", () => {
   it("should render a signature with a void return type", () => {

--- a/components/function/signature/index.tsx
+++ b/components/function/signature/index.tsx
@@ -21,7 +21,7 @@ const getReturnType = (
   return `[${outputs.map((output) => getType(output)).join(", ")}]`;
 };
 
-const Signature = ({ func }: SignatureProps) => {
+export const Signature = ({ func }: SignatureProps) => {
   const returnType = getReturnType(
     func.outputs as AbiParameterWithComponents[]
   );
@@ -37,5 +37,3 @@ const Signature = ({ func }: SignatureProps) => {
     </div>
   );
 };
-
-export default Signature;

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "testing/factory";
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
-import View from ".";
+import { View } from ".";
 
 vi.mock("wagmi");
 

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -9,7 +9,7 @@ import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
-import Signature from "../signature";
+import { Signature } from "../signature";
 
 type ViewProps = {
   address: Address;

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -16,7 +16,7 @@ type ViewProps = {
   func: AbiDefinedFunction;
 };
 
-const View = ({ address, func }: ViewProps) => {
+export const View = ({ address, func }: ViewProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -45,5 +45,3 @@ const View = ({ address, func }: ViewProps) => {
     </li>
   );
 };
-
-export default View;

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
-import Output from "../output";
+import { Output } from "../output";
 import Signature from "../signature";
 
 type ViewProps = {

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/button";
-import Inputs from "components/inputs";
+import { Inputs } from "components/inputs";
 import {
   AbiDefinedFunction,
   AbiParameterWithComponents,

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -1,4 +1,4 @@
-import Button from "components/button";
+import { Button } from "components/button";
 import Inputs from "components/inputs";
 import {
   AbiDefinedFunction,

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "core/types";
 import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
-import Container from "../container";
+import { Container } from "../container";
 import Output from "../output";
 import Signature from "../signature";
 

--- a/components/functions/index.test.tsx
+++ b/components/functions/index.test.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAbiDefinedFunctionList, buildAddress } from "testing/factory";
 import { useContractRead, useContractWrite } from "wagmi";
-import Functions from ".";
+import { Functions } from ".";
 
 vi.mock("wagmi");
 

--- a/components/functions/index.tsx
+++ b/components/functions/index.tsx
@@ -1,5 +1,5 @@
 import { AbiDefinedFunction, Address } from "core/types";
-import Function from "components/function";
+import { Function } from "components/function";
 
 type FunctionsProps = {
   address: Address;

--- a/components/functions/index.tsx
+++ b/components/functions/index.tsx
@@ -6,7 +6,7 @@ type FunctionsProps = {
   functions: AbiDefinedFunction[];
 };
 
-const Functions = ({ address, functions }: FunctionsProps) => {
+export const Functions = ({ address, functions }: FunctionsProps) => {
   if (functions.length === 0) return <div>No defined functions.</div>;
   return (
     <ul className="flex flex-col gap-4">
@@ -20,5 +20,3 @@ const Functions = ({ address, functions }: FunctionsProps) => {
     </ul>
   );
 };
-
-export default Functions;

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -7,7 +7,7 @@ type HeaderProps = {
   walletButtonText: string;
 };
 
-const Header = ({
+export const Header = ({
   resetActiveContract,
   toggleWallet,
   walletButtonText,
@@ -33,5 +33,3 @@ const Header = ({
     </section>
   </header>
 );
-
-export default Header;

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -1,5 +1,5 @@
 import { WalletIcon } from "@heroicons/react/24/outline";
-import Connect from "components/connect";
+import { Connect } from "components/connect";
 
 type HeaderProps = {
   resetActiveContract: () => void;

--- a/components/inputs/index.test.tsx
+++ b/components/inputs/index.test.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import { buildArg, buildArgList } from "testing/factory";
-import Inputs from ".";
+import { Inputs } from ".";
 
 const renderInputs = (props: Partial<ComponentProps<typeof Inputs>>) => {
   return render(

--- a/components/inputs/index.tsx
+++ b/components/inputs/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/button";
-import Field from "components/field";
+import { Field } from "components/field";
 import { Arg } from "core/types";
 import { ChangeEvent } from "react";
 

--- a/components/inputs/index.tsx
+++ b/components/inputs/index.tsx
@@ -1,4 +1,4 @@
-import Button from "components/button";
+import { Button } from "components/button";
 import Field from "components/field";
 import { Arg } from "core/types";
 import { ChangeEvent } from "react";

--- a/components/inputs/index.tsx
+++ b/components/inputs/index.tsx
@@ -12,7 +12,7 @@ type InputsProps = {
   child?: boolean;
 };
 
-const Inputs = ({
+export const Inputs = ({
   name,
   args,
   updateValue,
@@ -134,5 +134,3 @@ const Inputs = ({
     </ul>
   );
 };
-
-export default Inputs;

--- a/components/listbox/index.tsx
+++ b/components/listbox/index.tsx
@@ -8,7 +8,12 @@ type ListboxProps = {
   setSelected: Dispatch<SetStateAction<any>>;
 };
 
-const Listbox = ({ label, options, selected, setSelected }: ListboxProps) => (
+export const Listbox = ({
+  label,
+  options,
+  selected,
+  setSelected,
+}: ListboxProps) => (
   <HeadlessListbox value={selected} onChange={setSelected}>
     <HeadlessListbox.Label className="sr-only">{label}</HeadlessListbox.Label>
     <div className="relative text-right select-none">
@@ -35,5 +40,3 @@ const Listbox = ({ label, options, selected, setSelected }: ListboxProps) => (
     </div>
   </HeadlessListbox>
 );
-
-export default Listbox;

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -2,7 +2,7 @@ import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
-const Switch = () => {
+export const Switch = () => {
   const [hasMounted, setHasMounted] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
   const isDarkMode = resolvedTheme === "dark";
@@ -27,5 +27,3 @@ const Switch = () => {
     </button>
   );
 };
-
-export default Switch;

--- a/components/wallet/account/index.test.tsx
+++ b/components/wallet/account/index.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
 import { useAccount, useBalance } from "wagmi";
-import Account from ".";
+import { Account } from ".";
 
 vi.mock("wagmi");
 

--- a/components/wallet/account/index.tsx
+++ b/components/wallet/account/index.tsx
@@ -31,7 +31,7 @@ const Option = ({
   );
 };
 
-const Account = () => {
+export const Account = () => {
   const [accounts, setAccounts] = useState<Address[]>([]);
   const { address, connector } = useAccount();
   const { data: balance } = useBalance({ address });
@@ -73,5 +73,3 @@ const Account = () => {
     </div>
   );
 };
-
-export default Account;

--- a/components/wallet/index.test.tsx
+++ b/components/wallet/index.test.tsx
@@ -7,7 +7,7 @@ import {
   usePrepareSendTransaction,
   useSendTransaction,
 } from "wagmi";
-import Wallet from ".";
+import { Wallet } from ".";
 
 vi.mock("wagmi");
 

--- a/components/wallet/index.tsx
+++ b/components/wallet/index.tsx
@@ -5,7 +5,7 @@ type WalletProps = {
   open: boolean;
 };
 
-const Wallet = ({ open }: WalletProps) => {
+export const Wallet = ({ open }: WalletProps) => {
   if (!open) return <></>;
   return (
     <aside className="z-30 bg-white dark:bg-black border-l border-black dark:border-white p-2 fixed right-0 h-full w-full lg:w-96 overflow-y-auto overscroll-none">
@@ -16,5 +16,3 @@ const Wallet = ({ open }: WalletProps) => {
     </aside>
   );
 };
-
-export default Wallet;

--- a/components/wallet/index.tsx
+++ b/components/wallet/index.tsx
@@ -1,5 +1,5 @@
 import { Account } from "./account";
-import Transfer from "./transfer";
+import { Transfer } from "./transfer";
 
 type WalletProps = {
   open: boolean;

--- a/components/wallet/index.tsx
+++ b/components/wallet/index.tsx
@@ -1,4 +1,4 @@
-import Account from "./account";
+import { Account } from "./account";
 import Transfer from "./transfer";
 
 type WalletProps = {

--- a/components/wallet/transfer/index.test.tsx
+++ b/components/wallet/transfer/index.test.tsx
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
 import { usePrepareSendTransaction, useSendTransaction } from "wagmi";
-import Transfer from ".";
+import { Transfer } from ".";
 
 vi.mock("wagmi");
 

--- a/components/wallet/transfer/index.tsx
+++ b/components/wallet/transfer/index.tsx
@@ -1,4 +1,4 @@
-import Button from "components/button";
+import { Button } from "components/button";
 import Field from "components/field";
 import Listbox from "components/listbox";
 import { useEther } from "hooks";

--- a/components/wallet/transfer/index.tsx
+++ b/components/wallet/transfer/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/button";
 import { Field } from "components/field";
-import Listbox from "components/listbox";
+import { Listbox } from "components/listbox";
 import { useEther } from "hooks";
 import { ChangeEvent, useState } from "react";
 import { usePrepareSendTransaction, useSendTransaction } from "wagmi";

--- a/components/wallet/transfer/index.tsx
+++ b/components/wallet/transfer/index.tsx
@@ -5,7 +5,7 @@ import { useEther } from "hooks";
 import { ChangeEvent, useState } from "react";
 import { usePrepareSendTransaction, useSendTransaction } from "wagmi";
 
-const Transfer = () => {
+export const Transfer = () => {
   const [recipient, setRecipient] = useState("");
   const { value, formattedValue, handleValueChange, unit, units, setUnit } =
     useEther();
@@ -56,5 +56,3 @@ const Transfer = () => {
     </div>
   );
 };
-
-export default Transfer;

--- a/components/wallet/transfer/index.tsx
+++ b/components/wallet/transfer/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/button";
-import Field from "components/field";
+import { Field } from "components/field";
 import Listbox from "components/listbox";
 import { useEther } from "hooks";
 import { ChangeEvent, useState } from "react";

--- a/core/contract/index.ts
+++ b/core/contract/index.ts
@@ -26,11 +26,9 @@ const removeAll = async () => {
   return db.write();
 };
 
-const contract = {
+export const contract = {
   insert,
   findAll,
   remove,
   removeAll,
 };
-
-export default contract;

--- a/pages/api/contracts/[address].ts
+++ b/pages/api/contracts/[address].ts
@@ -1,4 +1,4 @@
-import contract from "core/contract";
+import { contract } from "core/contract";
 import type { Address } from "core/types";
 import { getAddress } from "core/utils";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/pages/api/contracts/index.ts
+++ b/pages/api/contracts/index.ts
@@ -1,4 +1,4 @@
-import contract from "core/contract";
+import { contract } from "core/contract";
 import type { ContractDetails } from "core/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 

--- a/pages/api/verify.ts
+++ b/pages/api/verify.ts
@@ -1,4 +1,4 @@
-import contract from "core/contract";
+import { contract } from "core/contract";
 import { getAddress } from "core/utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { compile } from "solc";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Contract } from "components/contract";
-import Contracts from "components/contracts";
+import { Contracts } from "components/contracts";
 import Footer from "components/footer";
 import Header from "components/header";
 import Wallet from "components/wallet";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import { Contract } from "components/contract";
 import { Contracts } from "components/contracts";
 import { Footer } from "components/footer";
 import { Header } from "components/header";
-import Wallet from "components/wallet";
+import { Wallet } from "components/wallet";
 import { Address } from "core/types";
 import { ethers } from "ethers";
 import { useToggle } from "hooks";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { Contract } from "components/contract";
 import { Contracts } from "components/contracts";
-import Footer from "components/footer";
+import { Footer } from "components/footer";
 import Header from "components/header";
 import Wallet from "components/wallet";
 import { Address } from "core/types";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Contract } from "components/contract";
 import { Contracts } from "components/contracts";
 import { Footer } from "components/footer";
-import Header from "components/header";
+import { Header } from "components/header";
 import Wallet from "components/wallet";
 import { Address } from "core/types";
 import { ethers } from "ethers";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import Contract from "components/contract";
+import { Contract } from "components/contract";
 import Contracts from "components/contracts";
 import Footer from "components/footer";
 import Header from "components/header";


### PR DESCRIPTION
## Motivation

Prefer named exports over default exports.

## Solution

Replace some default exports with named exports.