### PR TITLE
feat: configure forked chains

### DIFF
--- a/components/connect/index.tsx
+++ b/components/connect/index.tsx
@@ -59,7 +59,7 @@ export const Connect = () => {
                     type="button"
                     className="bg-black dark:bg-white text-white dark:text-black rounded-l-sm px-2 py-0.5 focus:italic focus:outline-none"
                   >
-                    {chain.name === "Chain 31337" ? "Localhost" : chain.name}
+                    {chain.name}
                   </button>
                   <button
                     onClick={openAccountModal}

--- a/core/chains/index.test.ts
+++ b/core/chains/index.test.ts
@@ -1,0 +1,18 @@
+import { forkedChains, foundry } from ".";
+
+describe("chains", () => {
+  it("should not append 'Fork' to foundry chain", () => {
+    expect(foundry.name).toBe("Foundry");
+  });
+
+  it.each(forkedChains)(
+    "should append 'Fork' to the name of the chain",
+    (forkedChain) => {
+      expect(forkedChain.name.endsWith(" Fork")).toBe(true);
+    }
+  );
+
+  it.each(forkedChains)("should use foundry rpcUrls", (forkedChain) => {
+    expect(forkedChain.rpcUrls).toEqual(foundry.rpcUrls);
+  });
+});

--- a/core/chains/index.ts
+++ b/core/chains/index.ts
@@ -1,0 +1,11 @@
+import { Chain, foundry, goerli, mainnet, sepolia } from "wagmi/chains";
+
+const fork = (chain: Chain) => ({
+  ...chain,
+  name: `${chain.name} Fork`,
+  rpcUrls: foundry.rpcUrls,
+});
+
+const forkedChains = [goerli, mainnet, sepolia].map(fork);
+
+export { foundry, forkedChains };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,12 +9,12 @@ import {
 } from "@rainbow-me/rainbowkit";
 import { ThemeProvider } from "next-themes";
 import { configureChains, createClient, WagmiConfig } from "wagmi";
-import { localhost } from "wagmi/chains";
 import { publicProvider } from "wagmi/providers/public";
 import { blacksmithWallet } from "packages/wallets";
+import { forkedChains, foundry } from "core/chains";
 
 const { chains, provider, webSocketProvider } = configureChains(
-  [localhost],
+  [foundry, ...forkedChains],
   [publicProvider()]
 );
 


### PR DESCRIPTION
## Motivation

The forked chain name should be shown rather than the chain id.

## Solution

Configure forked `mainnet`, `goerli`, and `sepolia` chains.

## Additional Notes

Replaces `localhost` chain with `foundry`.