### PR TITLE
refactor: extract inline types

### DIFF
--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -18,7 +18,9 @@ const Introduction = () => (
   </div>
 );
 
-export const Contract = ({ address }: { address: Address }) => {
+type ContractProps = { address: Address };
+
+export const Contract = ({ address }: ContractProps) => {
   const { contracts, isLoading, isError } = useContracts();
 
   if (isLoading) return <div>loading...</div>;

--- a/components/wallet/account/index.tsx
+++ b/components/wallet/account/index.tsx
@@ -13,10 +13,9 @@ const formatValue = (value: string) => {
   return value.slice(0, value.indexOf(".") + 2);
 };
 
-const Option = ({
-  address,
-  children,
-}: PropsWithChildren<{ address: Address }>) => {
+type OptionProps = PropsWithChildren<{ address: Address }>;
+
+const Option = ({ address, children }: OptionProps) => {
   const { data } = useBalance({ address });
   return (
     <Listbox.Option


### PR DESCRIPTION
## Motivation

Prefer named type definitions over inline types.

## Solution

- Extract `ContractProps` type
- Extract `OptionProps` type