### PR TITLE
feat: etherscan api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Select the Dai contract in the contracts sidebar and begin interacting!
 
 Example: Try entering `0xad0135af20fa82e106607257143d0060a7eb5cbf` into the `balanceOf` function.
 
+## Advanced Usage
+
+Create a `.env.local` in the root directory of Blacksmith and include your API key to avoid rate limits.
+
+```bash
+echo "ETHERSCAN_API_KEY=XXX" >> .env.local
+```
+
 ## Hardhat
 
 If you're working with Hardhat check out [🏗 scaffold-eth](https://github.com/scaffold-eth/scaffold-eth)!

--- a/components/contract/manager/index.tsx
+++ b/components/contract/manager/index.tsx
@@ -76,13 +76,13 @@ export const Manager = () => {
         <p className="max-w-prose">
           You can remove any contract from Blacksmith that you have imported or
           verified. You can import verified contracts from Etherscan by
-          providing a contract address (rate limited to one import every 5
-          seconds). You can interact with imported contracts by starting an
-          instance of Anvil that{" "}
+          providing a contract address. You can interact with imported contracts
+          by starting an instance of Anvil that{" "}
           <Anchor href="https://book.getfoundry.sh/tutorials/forking-mainnet-with-cast-anvil">
             forks mainnet
           </Anchor>
-          .
+          . To avoid rate limits read the Advanced Usage section of the
+          Blacksmith README.
         </p>
         <ul>
           <Field

--- a/pages/api/contracts/[address].ts
+++ b/pages/api/contracts/[address].ts
@@ -3,19 +3,22 @@ import type { Address } from "core/types";
 import { getAddress } from "core/utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+const BASE_URL = "https://api.etherscan.io";
+
+const buildGetSourceCodeUrl = (address: Address) => {
+  return `${BASE_URL}/api?module=contract&action=getsourcecode&address=${address}`;
+};
+
 const postHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const address = getAddress(req.query.address as Address);
   if (!address) {
     return res.status(400).json({ error: "Invalid address" });
   }
-  return fetch(
-    `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${req.query.address}`,
-    {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }
-  )
+  return fetch(buildGetSourceCodeUrl(address), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
     .then((response) => response.json())
     .then((data) => {
       const { ABI, ContractName, CompilerVersion } = data.result[0];

--- a/pages/api/contracts/[address].ts
+++ b/pages/api/contracts/[address].ts
@@ -6,7 +6,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 const BASE_URL = "https://api.etherscan.io";
 
 const buildGetSourceCodeUrl = (address: Address) => {
-  return `${BASE_URL}/api?module=contract&action=getsourcecode&address=${address}`;
+  const apiKey = process.env.ETHERSCAN_API_KEY;
+  return `${BASE_URL}/api?module=contract&action=getsourcecode&address=${address}${
+    apiKey ? `&apikey=${apiKey}` : ""
+  }`;
 };
 
 const postHandler = async (req: NextApiRequest, res: NextApiResponse) => {


### PR DESCRIPTION
## Motivation

Users should be able to avoid rate limits by providing an Etherscan API key.

## Solution

Attempt Etherscan API key retrieval from `process.env` on contract address import.