### PR TITLE
refactor: reduce bundle size imports

### DIFF
--- a/components/contract/index.test.tsx
+++ b/components/contract/index.test.tsx
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { AddressZero } from "core/constants";
 import { server } from "mocks/server";
 import { rest } from "msw";
 import { ComponentProps } from "react";
@@ -100,7 +100,7 @@ describe("Contract", () => {
 
   it("does not render the not found page if the address is zero", async () => {
     const contract = buildContractDetailsList(2);
-    const address = ethers.constants.AddressZero;
+    const address = AddressZero;
     server.use(
       rest.get("/api/contracts", (_req, res, ctx) => {
         return res(ctx.json([contract]));

--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -1,8 +1,8 @@
 import { Square2StackIcon } from "@heroicons/react/24/outline";
 import { Balance } from "components/balance";
 import { Functions } from "components/functions";
+import { AddressZero } from "core/constants";
 import { Abi, AbiDefinedFunction, Address } from "core/types";
-import { ethers } from "ethers";
 import { useContracts } from "hooks";
 import { Manager } from "./manager";
 import { Setup } from "./setup";
@@ -25,11 +25,7 @@ export const Contract = ({ address }: ContractProps) => {
 
   if (isLoading) return <div>loading...</div>;
   if (isError) return <div>error</div>;
-  if (
-    !contracts ||
-    contracts.length === 0 ||
-    address === ethers.constants.AddressZero
-  )
+  if (!contracts || contracts.length === 0 || address === AddressZero)
     return <Introduction />;
 
   const contract = contracts.find((contract) => contract.address === address);

--- a/components/contracts/index.test.tsx
+++ b/components/contracts/index.test.tsx
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { AddressZero } from "core/constants";
 import { server } from "mocks/server";
 import { rest } from "msw";
 import { ComponentProps } from "react";
@@ -9,7 +9,7 @@ import { Contracts } from ".";
 const renderContracts = (
   props: Partial<ComponentProps<typeof Contracts>> = {}
 ) => {
-  const activeContract = ethers.constants.AddressZero;
+  const activeContract = AddressZero;
   const setActiveContract = vi.fn();
   return render(
     <Contracts

--- a/core/constants/index.ts
+++ b/core/constants/index.ts
@@ -1,0 +1,3 @@
+const AddressZero = "0x0000000000000000000000000000000000000000";
+
+export { AddressZero };

--- a/core/utils/index.ts
+++ b/core/utils/index.ts
@@ -1,9 +1,9 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import { Address } from "core/types";
 
 const getAddress = (address: Address) => {
   try {
-    return ethers.utils.getAddress(address);
+    return utils.getAddress(address);
   } catch {
     return null;
   }

--- a/hooks/useArgs/index.test.tsx
+++ b/hooks/useArgs/index.test.tsx
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { AbiParameterWithComponents } from "core/types";
 import { BigNumber } from "ethers";
-import { times } from "lodash";
+import times from "lodash/times";
 import { act, renderHook } from "testing";
 import {
   buildAddress,

--- a/hooks/useArgs/index.ts
+++ b/hooks/useArgs/index.ts
@@ -1,6 +1,6 @@
 import { AbiParameterWithComponents, Arg } from "core/types";
 import { BigNumber } from "ethers";
-import { times } from "lodash";
+import times from "lodash/times";
 import { useCallback, useState } from "react";
 
 const tryBigNumberConversion = (value: string): BigNumber | string => {

--- a/hooks/useEther/index.ts
+++ b/hooks/useEther/index.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import { ChangeEvent, useCallback, useState } from "react";
 
 export enum Units {
@@ -11,7 +11,7 @@ export enum Units {
 export const useEther = () => {
   const [unit, setUnit] = useState(Units.wei);
   const [value, setValue] = useState("");
-  const formattedValue = ethers.utils.parseUnits(value || "0", unit);
+  const formattedValue = utils.parseUnits(value || "0", unit);
   const handleValueChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const updatedValue = event.target.value.replace(/\D/g, "");

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,22 +3,19 @@ import { Contracts } from "components/contracts";
 import { Footer } from "components/footer";
 import { Header } from "components/header";
 import { Wallet } from "components/wallet";
+import { AddressZero } from "core/constants";
 import { Address } from "core/types";
-import { ethers } from "ethers";
 import { useToggle } from "hooks";
 import type { NextPage } from "next";
 import Head from "next/head";
 import { useState } from "react";
 
 const Home: NextPage = () => {
-  const [activeContract, setActiveContract] = useState<Address>(
-    ethers.constants.AddressZero
-  );
+  const [activeContract, setActiveContract] = useState<Address>(AddressZero);
   const { state: isWalletOpen, toggle: toggleWallet } = useToggle(false);
   const walletButtonText = isWalletOpen ? "close wallet" : "open wallet";
 
-  const resetActiveContract = () =>
-    setActiveContract(ethers.constants.AddressZero);
+  const resetActiveContract = () => setActiveContract(AddressZero);
 
   return (
     <section className="text-black dark:text-white dark:bg-black min-h-screen max-h-screen flex flex-col overflow-hidden selection:bg-black selection:text-white dark:selection:bg-white dark:selection:text-black">

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -9,7 +9,8 @@ import {
   ContractDetails,
 } from "core/types";
 import { faker } from "@faker-js/faker";
-import { capitalize, times } from "lodash";
+import capitalize from "lodash/capitalize";
+import times from "lodash/times";
 import { Result } from "ethers/lib/utils";
 
 const RESERVED_WORDS = ["value"];

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -11,7 +11,6 @@ import {
 import { faker } from "@faker-js/faker";
 import capitalize from "lodash/capitalize";
 import times from "lodash/times";
-import { Result } from "ethers/lib/utils";
 
 const RESERVED_WORDS = ["value"];
 
@@ -109,7 +108,7 @@ export const buildOutput = (
 export const buildOutputList = (n: number): AbiParameter[] =>
   times(n, () => buildOutput());
 
-export const buildResult = (value: any): Result => value as Result;
+export const buildResult = (value: any) => value;
 
 export const buildTransactionHash = () =>
   faker.datatype.hexadecimal({ length: 64, case: "lower" });


### PR DESCRIPTION
## Motivation

Reduce bundle size.

## Solution

- Use tree shaking imports
- Remove erroneous type imports
- Create local copy of `AddressZero`