### PR TITLE
refactor: replace any type with result

### DIFF
--- a/components/function/output/index.tsx
+++ b/components/function/output/index.tsx
@@ -1,12 +1,14 @@
+import { Result } from "core/types";
+
 type OutputProps = {
-  data: any | undefined;
+  data: Result;
   isTouched: boolean;
   isLoading: boolean;
   isError: boolean;
   error: any | null;
 };
 
-const formatData = (data: any | undefined): string => {
+const formatData = (data: Result): string => {
   if (data === undefined || data === null) return "";
   if (typeof data === "string") return data;
   if (Array.isArray(data)) return `(${data.map(formatData).join(", ")})`;

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -4,6 +4,7 @@ import {
   AbiDefinedFunction,
   AbiParameterWithComponents,
   Address,
+  Result,
 } from "core/types";
 import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
@@ -20,7 +21,11 @@ export const Pure = ({ address, func }: PureProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
-  const { data, isLoading, isError, error, refetch } = useContractRead({
+  const { data, isLoading, isError, error, refetch } = useContractRead<
+    [AbiDefinedFunction],
+    string,
+    Result
+  >({
     address,
     abi: [func],
     functionName: func.name,

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -4,6 +4,7 @@ import {
   AbiDefinedFunction,
   AbiParameterWithComponents,
   Address,
+  Result,
 } from "core/types";
 import { useArgs } from "hooks";
 import { useContractRead } from "wagmi";
@@ -20,7 +21,11 @@ export const View = ({ address, func }: ViewProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
-  const { data, isLoading, isError, error, refetch } = useContractRead({
+  const { data, isLoading, isError, error, refetch } = useContractRead<
+    [AbiDefinedFunction],
+    string,
+    Result
+  >({
     address,
     abi: [func],
     functionName: func.name,

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -1,4 +1,5 @@
 import type { Abi, AbiParameter, AbiStateMutability, Address } from "abitype";
+import { BigNumber } from "ethers";
 
 export type Arg = {
   name: string;
@@ -27,5 +28,7 @@ export type ContractDetails = {
   name: string;
   version: string;
 };
+
+export type Result = string | BigNumber | undefined | null | Result[];
 
 export * from "abitype";

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -7,6 +7,7 @@ import {
   Address,
   Arg,
   ContractDetails,
+  Result,
 } from "core/types";
 import { faker } from "@faker-js/faker/locale/en";
 import capitalize from "lodash/capitalize";
@@ -108,7 +109,7 @@ export const buildOutput = (
 export const buildOutputList = (n: number): AbiParameter[] =>
   times(n, () => buildOutput());
 
-export const buildResult = (value: any) => value;
+export const buildResult = (value: Result) => value;
 
 export const buildTransactionHash = () =>
   faker.datatype.hexadecimal({ length: 64, case: "lower" });


### PR DESCRIPTION
## Motivation

Improve type checking by replacing `any` usages.

## Solution

Create a custom `Result` type for contract hook data.