### PR TITLE
Collapsible functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 # misc
 .DS_Store
 *.pem
+.idea/
+.vscode/
 
 # debug
 npm-debug.log*

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
 import { Nonpayable } from ".";
+import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -20,12 +21,15 @@ useContractWriteMock.mockReturnValue({ write: vi.fn() });
 const renderNonpayable = (
   props: Partial<ComponentProps<typeof Nonpayable>> = {}
 ) => {
-  return render(
-    <Nonpayable
-      address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
-    />
+  const func = props.func || buildAbiDefinedFunction();
+  const view = render(
+    <Nonpayable address={props.address || buildAddress()} func={func} />
   );
+  // Expand all signatures for easier testing
+  act(() => {
+    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
+  });
+  return view;
 };
 
 describe("Nonpayable", () => {

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -7,6 +7,7 @@ import {
   Address,
 } from "core/types";
 import { useArgs } from "hooks";
+import React from "react";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -36,23 +37,33 @@ export const Nonpayable = ({ address, func }: NonpayableProps) => {
   const handleClick = () => {
     write?.();
   };
+  const [collapsed, setCollapsed] = React.useState(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
-      <Signature func={func} />
-      <Inputs name={func.name} args={args} updateValue={updateValue} />
-      <Container>
-        <Button type="button" disabled={isDisabled} onClick={handleClick}>
-          write
-        </Button>
-        <Output
-          data={data ? data.hash : undefined}
-          isTouched={isTouched}
-          isLoading={isLoading}
-          isError={isError}
-          error={error}
-        />
-      </Container>
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+
+      {!collapsed && (
+        <>
+          <Inputs name={func.name} args={args} updateValue={updateValue} />
+          <Container>
+            <Button type="button" disabled={isDisabled} onClick={handleClick}>
+              write
+            </Button>
+            <Output
+              data={data ? data.hash : undefined}
+              isTouched={isTouched}
+              isLoading={isLoading}
+              isError={isError}
+              error={error}
+            />
+          </Container>
+        </>
+      )}
     </li>
   );
 };

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
 import { Payable } from ".";
+import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -18,12 +19,15 @@ const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
 const renderPayable = (props: Partial<ComponentProps<typeof Payable>> = {}) => {
-  return render(
-    <Payable
-      address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
-    />
+  const func = props.func || buildAbiDefinedFunction();
+  const view = render(
+    <Payable address={props.address || buildAddress()} func={func} />
   );
+  // Expand all signatures for easier testing
+  act(() => {
+    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
+  });
+  return view;
 };
 
 describe("Payable", () => {

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -9,6 +9,7 @@ import {
   Address,
 } from "core/types";
 import { useArgs, useEther } from "hooks";
+import React from "react";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -43,40 +44,50 @@ export const Payable = ({ address, func }: PayableProps) => {
   const handleClick = () => {
     write?.();
   };
+  const [collapsed, setCollapsed] = React.useState(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
-      <Signature func={func} />
-      <section className="flex flex-col">
-        <div className="flex gap-1">
-          <Field
-            id={`${func.name}-value`}
-            inputName="value"
-            value={value}
-            type="uint256"
-            handleChange={handleValueChange}
-          />
-          <Listbox
-            label="unit"
-            options={units}
-            selected={unit}
-            setSelected={setUnit}
-          />
-        </div>
-      </section>
-      <Inputs name={func.name} args={args} updateValue={updateValue} />
-      <Container>
-        <Button type="button" disabled={isDisabled} onClick={handleClick}>
-          send
-        </Button>
-        <Output
-          data={data ? data.hash : undefined}
-          isTouched={isTouched}
-          isLoading={isLoading}
-          isError={isError}
-          error={error}
-        />
-      </Container>
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+
+      {!collapsed && (
+        <>
+          <section className="flex flex-col">
+            <div className="flex gap-1">
+              <Field
+                id={`${func.name}-value`}
+                inputName="value"
+                value={value}
+                type="uint256"
+                handleChange={handleValueChange}
+              />
+              <Listbox
+                label="unit"
+                options={units}
+                selected={unit}
+                setSelected={setUnit}
+              />
+            </div>
+          </section>
+          <Inputs name={func.name} args={args} updateValue={updateValue} />
+          <Container>
+            <Button type="button" disabled={isDisabled} onClick={handleClick}>
+              send
+            </Button>
+            <Output
+              data={data ? data.hash : undefined}
+              isTouched={isTouched}
+              isLoading={isLoading}
+              isError={isError}
+              error={error}
+            />
+          </Container>
+        </>
+      )}
     </li>
   );
 };

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -10,6 +10,7 @@ import {
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { Pure } from ".";
+import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -23,12 +24,15 @@ useContractReadMock.mockReturnValue({
 });
 
 const renderPure = (props: Partial<ComponentProps<typeof Pure>> = {}) => {
-  return render(
-    <Pure
-      address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
-    />
+  const func = props.func || buildAbiDefinedFunction();
+  const view = render(
+    <Pure address={props.address || buildAddress()} func={func} />
   );
+  // Expand all signatures for easier testing
+  act(() => {
+    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
+  });
+  return view;
 };
 
 describe("Pure", () => {

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -8,6 +8,7 @@ import {
   Result,
 } from "core/types";
 import { useArgs } from "hooks";
+import React from "react";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -33,21 +34,31 @@ export const Pure = ({ address, func }: PureProps) => {
     args: formattedArgs,
     watch: true,
   });
+  const [collapsed, setCollapsed] = React.useState(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
-      <Signature func={func} />
-      <Inputs name={func.name} args={args} updateValue={updateValue} />
-      <Container>
-        <Button onClick={() => refetch()}>read</Button>
-        <Output
-          data={data}
-          isTouched={isTouched}
-          isLoading={isLoading}
-          isError={isError}
-          error={error}
-        />
-      </Container>
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+
+      {!collapsed && (
+        <>
+          <Inputs name={func.name} args={args} updateValue={updateValue} />
+          <Container>
+            <Button onClick={() => refetch()}>read</Button>
+            <Output
+              data={data}
+              isTouched={isTouched}
+              isLoading={isLoading}
+              isError={isError}
+              error={error}
+            />
+          </Container>
+        </>
+      )}
     </li>
   );
 };

--- a/components/function/signature/index.test.tsx
+++ b/components/function/signature/index.test.tsx
@@ -10,8 +10,18 @@ import { Signature } from ".";
 describe("Signature", () => {
   it("should render a signature with a void return type", () => {
     const func = buildAbiDefinedFunction();
+    let collapsed = false;
+    let setCollapsed = () => {
+      collapsed = !collapsed;
+    };
 
-    render(<Signature func={func} />);
+    render(
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
 
     expect(
       screen.getByRole("heading", { level: 4, name: `${func.name} → void` })
@@ -21,8 +31,18 @@ describe("Signature", () => {
   it("should render a signature with a single return type", () => {
     const outputs = buildOutputList(1);
     const func = buildAbiDefinedFunction({ outputs });
+    let collapsed = false;
+    let setCollapsed = () => {
+      collapsed = !collapsed;
+    };
 
-    render(<Signature func={func} />);
+    render(
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
 
     expect(
       screen.getByRole("heading", {
@@ -35,8 +55,18 @@ describe("Signature", () => {
   it("should render a signature with multiple return types", () => {
     const outputs = buildOutputList(2);
     const func = buildAbiDefinedFunction({ outputs });
+    let collapsed = false;
+    let setCollapsed = () => {
+      collapsed = !collapsed;
+    };
 
-    render(<Signature func={func} />);
+    render(
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
 
     expect(
       screen.getByRole("heading", {
@@ -50,8 +80,18 @@ describe("Signature", () => {
     const components = buildOutputList(2) as AbiParameterWithComponents[];
     const output = buildOutput({ type: "tuple", components });
     const func = buildAbiDefinedFunction({ outputs: [output] });
+    let collapsed = false;
+    let setCollapsed = () => {
+      collapsed = !collapsed;
+    };
 
-    render(<Signature func={func} />);
+    render(
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
 
     expect(
       screen.getByRole("heading", {
@@ -66,8 +106,18 @@ describe("Signature", () => {
     const output = buildOutput({ type: "tuple", components });
     const outputs = [output, ...buildOutputList(2)];
     const func = buildAbiDefinedFunction({ outputs });
+    let collapsed = false;
+    let setCollapsed = () => {
+      collapsed = !collapsed;
+    };
 
-    render(<Signature func={func} />);
+    render(
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
 
     expect(
       screen.getByRole("heading", {

--- a/components/function/signature/index.test.tsx
+++ b/components/function/signature/index.test.tsx
@@ -2,12 +2,36 @@ import { AbiParameterWithComponents } from "core/types";
 import { render, screen } from "testing";
 import {
   buildAbiDefinedFunction,
+  buildInputList,
   buildOutput,
   buildOutputList,
 } from "testing/factory";
 import { Signature } from ".";
+import { act } from "@testing-library/react";
 
 describe("Signature", () => {
+  it("should expand and collapse a function signature", () => {
+    const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
+    let collapsed = true;
+    let setCollapsed = () => {
+      collapsed = !collapsed;
+    };
+
+    render(
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+    );
+
+    expect(screen.findAllByText(func.inputs[0].name!)).resolves.toHaveLength(0);
+    act(() => {
+      screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
+    });
+    expect(screen.findAllByText(func.inputs[0].name!)).resolves.toHaveLength(1);
+  });
+
   it("should render a signature with a void return type", () => {
     const func = buildAbiDefinedFunction();
     let collapsed = false;

--- a/components/function/signature/index.tsx
+++ b/components/function/signature/index.tsx
@@ -1,7 +1,11 @@
+import { MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { Dispatch, SetStateAction } from "react";
 import { AbiDefinedFunction, AbiParameterWithComponents } from "core/types";
 
 type SignatureProps = {
   func: AbiDefinedFunction;
+  collapsed: boolean;
+  setCollapsed: Dispatch<SetStateAction<boolean>>;
 };
 
 const getType = (output: AbiParameterWithComponents): string => {
@@ -21,10 +25,17 @@ const getReturnType = (
   return `[${outputs.map((output) => getType(output)).join(", ")}]`;
 };
 
-export const Signature = ({ func }: SignatureProps) => {
+export const Signature = ({
+  func,
+  collapsed,
+  setCollapsed,
+}: SignatureProps) => {
   const returnType = getReturnType(
     func.outputs as AbiParameterWithComponents[]
   );
+  const handleCollapseToggle = () => {
+    setCollapsed((collapsed) => !collapsed);
+  };
 
   return (
     <div className="flex items-center gap-2">
@@ -34,6 +45,17 @@ export const Signature = ({ func }: SignatureProps) => {
       <span className="text-xs font-medium border border-black dark:border-white rounded px-1 py-0.5">
         {func.stateMutability}
       </span>
+      <button
+        className="inline p-0.5 mx-0.5 rounded-sm text-black dark:text-white focus:bg-black focus:text-white dark:focus:bg-white dark:focus:text-black focus:outline-none"
+        onClick={handleCollapseToggle}
+        data-testid={`signature-toggle-collapse-${func.name}`}
+      >
+        {collapsed ? (
+          <PlusIcon className="h-4 w-4" />
+        ) : (
+          <MinusIcon className="h-4 w-4" />
+        )}
+      </button>
     </div>
   );
 };

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -10,6 +10,8 @@ import {
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { View } from ".";
+import { AbiDefinedFunction } from "../../../core/types";
+import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -23,12 +25,15 @@ useContractReadMock.mockReturnValue({
 });
 
 const renderView = (props: Partial<ComponentProps<typeof View>> = {}) => {
-  return render(
-    <View
-      address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
-    />
+  const func = props.func || buildAbiDefinedFunction();
+  const view = render(
+    <View address={props.address || buildAddress()} func={func} />
   );
+  // Expand all signatures for easier testing
+  act(() => {
+    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
+  });
+  return view;
 };
 
 describe("View", () => {

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -8,6 +8,7 @@ import {
   Result,
 } from "core/types";
 import { useArgs } from "hooks";
+import React from "react";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -33,21 +34,31 @@ export const View = ({ address, func }: ViewProps) => {
     args: formattedArgs,
     watch: true,
   });
+  const [collapsed, setCollapsed] = React.useState(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
-      <Signature func={func} />
-      <Inputs name={func.name} args={args} updateValue={updateValue} />
-      <Container>
-        <Button onClick={() => refetch()}>read</Button>
-        <Output
-          data={data}
-          isTouched={isTouched}
-          isLoading={isLoading}
-          isError={isError}
-          error={error}
-        />
-      </Container>
+      <Signature
+        func={func}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+      />
+
+      {!collapsed && (
+        <>
+          <Inputs name={func.name} args={args} updateValue={updateValue} />
+          <Container>
+            <Button onClick={() => refetch()}>read</Button>
+            <Output
+              data={data}
+              isTouched={isTouched}
+              isLoading={isLoading}
+              isError={isError}
+              error={error}
+            />
+          </Container>
+        </>
+      )}
     </li>
   );
 };


### PR DESCRIPTION
appreciate your patience on this @unholypanda! 🙇 ski season stoke surpassed the dev itch for a little bit there :)

getting a fresh start on [this pr](https://github.com/blacksmith-eth/blacksmith/pull/1) now with the new contrib guidelines and pr template

## Motivation

<!-- Describe why this change is being proposed. -->

more complex contracts such as seaport looked a little cluttered once imported

![image](https://user-images.githubusercontent.com/1211977/212598850-b0ebcf32-9990-46b6-b0ef-f82378254f37.png)

## Solution

<!-- Describe the changes that resolve the issue or implement the feature. -->

Add a +/- collapse toggle to each function in a contract's ABI. This has the effect of making navigation to a specific method easier for complex ABIs, while sacrificing a little friction for contracts with simpler signatures.

![image](https://user-images.githubusercontent.com/1211977/212598679-2a107a30-31c2-4794-bac4-92db1562fef0.png)

## Additional Notes

<!-- Provide any additional information that may be helpful for review. -->

I saw CI will still need to be approved to run, but i've gone through the steps noted in the [contributing doc](https://github.com/blacksmith-eth/blacksmith/blob/930eba71ba23c63d6fb842a2731a3e28064dcc79/.github/CONTRIBUTING.md) and it all looks green now
