### PR TITLE
refactor: use toggle hook for collapse

### DIFF
--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -12,12 +12,14 @@ type FunctionProps = {
 export const Function = ({ address, func }: FunctionProps) => {
   switch (func.stateMutability) {
     case "pure":
-      return <Pure address={address} func={func} />;
+      return <Pure address={address} func={func} initialCollapsed={true} />;
     case "view":
-      return <View address={address} func={func} />;
+      return <View address={address} func={func} initialCollapsed={true} />;
     case "nonpayable":
-      return <Nonpayable address={address} func={func} />;
+      return (
+        <Nonpayable address={address} func={func} initialCollapsed={true} />
+      );
     case "payable":
-      return <Payable address={address} func={func} />;
+      return <Payable address={address} func={func} initialCollapsed={true} />;
   }
 };

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -11,7 +11,6 @@ import {
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
 import { Nonpayable } from ".";
-import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -21,18 +20,27 @@ useContractWriteMock.mockReturnValue({ write: vi.fn() });
 const renderNonpayable = (
   props: Partial<ComponentProps<typeof Nonpayable>> = {}
 ) => {
-  const func = props.func || buildAbiDefinedFunction();
-  const view = render(
-    <Nonpayable address={props.address || buildAddress()} func={func} />
+  return render(
+    <Nonpayable
+      address={props.address || buildAddress()}
+      func={props.func || buildAbiDefinedFunction()}
+      initialCollapsed={props.initialCollapsed || false}
+    />
   );
-  // Expand all signatures for easier testing
-  act(() => {
-    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
-  });
-  return view;
 };
 
 describe("Nonpayable", () => {
+  it("should not render inputs when initialCollapsed is true", () => {
+    const inputs = buildInputList(2);
+    const func = buildAbiDefinedFunction({ inputs });
+
+    renderNonpayable({ func, initialCollapsed: true });
+
+    func.inputs.forEach((input) => {
+      expect(screen.queryByLabelText(input.name!)).not.toBeInTheDocument();
+    });
+  });
+
   it("should render function name", () => {
     const func = buildAbiDefinedFunction();
 

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -15,9 +15,14 @@ import { Signature } from "../signature";
 type NonpayableProps = {
   address: Address;
   func: AbiDefinedFunction;
+  initialCollapsed: boolean;
 };
 
-export const Nonpayable = ({ address, func }: NonpayableProps) => {
+export const Nonpayable = ({
+  address,
+  func,
+  initialCollapsed,
+}: NonpayableProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -36,7 +41,8 @@ export const Nonpayable = ({ address, func }: NonpayableProps) => {
   const handleClick = () => {
     write?.();
   };
-  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
+  const { state: collapsed, toggle: toggleCollapsed } =
+    useToggle(initialCollapsed);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -6,8 +6,7 @@ import {
   AbiParameterWithComponents,
   Address,
 } from "core/types";
-import { useArgs } from "hooks";
-import React from "react";
+import { useArgs, useToggle } from "hooks";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -37,14 +36,14 @@ export const Nonpayable = ({ address, func }: NonpayableProps) => {
   const handleClick = () => {
     write?.();
   };
-  const [collapsed, setCollapsed] = React.useState(true);
+  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
       <Signature
         func={func}
         collapsed={collapsed}
-        setCollapsed={setCollapsed}
+        toggleCollapsed={toggleCollapsed}
       />
 
       {!collapsed && (

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -11,7 +11,6 @@ import {
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
 import { Payable } from ".";
-import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -19,18 +18,27 @@ const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
 const renderPayable = (props: Partial<ComponentProps<typeof Payable>> = {}) => {
-  const func = props.func || buildAbiDefinedFunction();
-  const view = render(
-    <Payable address={props.address || buildAddress()} func={func} />
+  return render(
+    <Payable
+      address={props.address || buildAddress()}
+      func={props.func || buildAbiDefinedFunction()}
+      initialCollapsed={props.initialCollapsed || false}
+    />
   );
-  // Expand all signatures for easier testing
-  act(() => {
-    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
-  });
-  return view;
 };
 
 describe("Payable", () => {
+  it("should not render inputs when initialCollapsed is true", () => {
+    const inputs = buildInputList(2);
+    const func = buildAbiDefinedFunction({ inputs });
+
+    renderPayable({ func, initialCollapsed: true });
+
+    func.inputs.forEach((input) => {
+      expect(screen.queryByLabelText(input.name!)).not.toBeInTheDocument();
+    });
+  });
+
   it("should render function name", () => {
     const func = buildAbiDefinedFunction();
 

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -17,9 +17,10 @@ import { Signature } from "../signature";
 type PayableProps = {
   address: Address;
   func: AbiDefinedFunction;
+  initialCollapsed: boolean;
 };
 
-export const Payable = ({ address, func }: PayableProps) => {
+export const Payable = ({ address, func, initialCollapsed }: PayableProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -43,7 +44,8 @@ export const Payable = ({ address, func }: PayableProps) => {
   const handleClick = () => {
     write?.();
   };
-  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
+  const { state: collapsed, toggle: toggleCollapsed } =
+    useToggle(initialCollapsed);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -8,8 +8,7 @@ import {
   AbiParameterWithComponents,
   Address,
 } from "core/types";
-import { useArgs, useEther } from "hooks";
-import React from "react";
+import { useArgs, useEther, useToggle } from "hooks";
 import { useContractWrite } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -44,14 +43,14 @@ export const Payable = ({ address, func }: PayableProps) => {
   const handleClick = () => {
     write?.();
   };
-  const [collapsed, setCollapsed] = React.useState(true);
+  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
       <Signature
         func={func}
         collapsed={collapsed}
-        setCollapsed={setCollapsed}
+        toggleCollapsed={toggleCollapsed}
       />
 
       {!collapsed && (

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -10,7 +10,6 @@ import {
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { Pure } from ".";
-import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -24,18 +23,27 @@ useContractReadMock.mockReturnValue({
 });
 
 const renderPure = (props: Partial<ComponentProps<typeof Pure>> = {}) => {
-  const func = props.func || buildAbiDefinedFunction();
-  const view = render(
-    <Pure address={props.address || buildAddress()} func={func} />
+  return render(
+    <Pure
+      address={props.address || buildAddress()}
+      func={props.func || buildAbiDefinedFunction()}
+      initialCollapsed={props.initialCollapsed || false}
+    />
   );
-  // Expand all signatures for easier testing
-  act(() => {
-    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
-  });
-  return view;
 };
 
 describe("Pure", () => {
+  it("should not render inputs when initialCollapsed is true", () => {
+    const inputs = buildInputList(2);
+    const func = buildAbiDefinedFunction({ inputs });
+
+    renderPure({ func, initialCollapsed: true });
+
+    func.inputs.forEach((input) => {
+      expect(screen.queryByLabelText(input.name!)).not.toBeInTheDocument();
+    });
+  });
+
   it("should render function name", () => {
     const func = buildAbiDefinedFunction();
 

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -16,9 +16,10 @@ import { Signature } from "../signature";
 type PureProps = {
   address: Address;
   func: AbiDefinedFunction;
+  initialCollapsed: boolean;
 };
 
-export const Pure = ({ address, func }: PureProps) => {
+export const Pure = ({ address, func, initialCollapsed }: PureProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -33,7 +34,8 @@ export const Pure = ({ address, func }: PureProps) => {
     args: formattedArgs,
     watch: true,
   });
-  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
+  const { state: collapsed, toggle: toggleCollapsed } =
+    useToggle(initialCollapsed);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -7,8 +7,7 @@ import {
   Address,
   Result,
 } from "core/types";
-import { useArgs } from "hooks";
-import React from "react";
+import { useArgs, useToggle } from "hooks";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -34,14 +33,14 @@ export const Pure = ({ address, func }: PureProps) => {
     args: formattedArgs,
     watch: true,
   });
-  const [collapsed, setCollapsed] = React.useState(true);
+  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
       <Signature
         func={func}
         collapsed={collapsed}
-        setCollapsed={setCollapsed}
+        toggleCollapsed={toggleCollapsed}
       />
 
       {!collapsed && (

--- a/components/function/signature/index.test.tsx
+++ b/components/function/signature/index.test.tsx
@@ -7,7 +7,6 @@ import {
   buildOutputList,
 } from "testing/factory";
 import { Signature } from ".";
-import { act } from "@testing-library/react";
 import { ComponentProps } from "react";
 
 const renderSignature = (props: Partial<ComponentProps<typeof Signature>>) => {
@@ -21,16 +20,36 @@ const renderSignature = (props: Partial<ComponentProps<typeof Signature>>) => {
 };
 
 describe("Signature", () => {
-  it("should expand and collapse a function signature", () => {
-    const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
+  it("should render collapse icon when expanded", () => {
+    const func = buildAbiDefinedFunction({ inputs: buildInputList(1) });
 
-    renderSignature({ func });
+    renderSignature({ func, collapsed: false });
 
-    expect(screen.findAllByText(func.inputs[0].name!)).resolves.toHaveLength(0);
-    act(() => {
-      screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
-    });
-    expect(screen.findAllByText(func.inputs[0].name!)).resolves.toHaveLength(1);
+    const collapseButton = screen.getByRole("button", { name: "Collapse" });
+
+    expect(collapseButton).toBeInTheDocument();
+  });
+
+  it("should render expand icon when collapsed", () => {
+    const func = buildAbiDefinedFunction({ inputs: buildInputList(1) });
+
+    renderSignature({ func, collapsed: true });
+
+    const expandButton = screen.getByRole("button", { name: "Expand" });
+
+    expect(expandButton).toBeInTheDocument();
+  });
+
+  it("should call toggleCollapsed function when the toggle is clicked", async () => {
+    const func = buildAbiDefinedFunction();
+    const toggleCollapsed = vi.fn();
+
+    const { user } = renderSignature({ func, toggleCollapsed });
+
+    const collapseButton = screen.getByRole("button", { name: "Collapse" });
+    await user.click(collapseButton);
+
+    expect(toggleCollapsed).toHaveBeenCalledOnce();
   });
 
   it("should render a signature with a void return type", () => {

--- a/components/function/signature/index.test.tsx
+++ b/components/function/signature/index.test.tsx
@@ -8,22 +8,23 @@ import {
 } from "testing/factory";
 import { Signature } from ".";
 import { act } from "@testing-library/react";
+import { ComponentProps } from "react";
+
+const renderSignature = (props: Partial<ComponentProps<typeof Signature>>) => {
+  return render(
+    <Signature
+      func={props.func || buildAbiDefinedFunction()}
+      collapsed={props.collapsed || false}
+      toggleCollapsed={props.toggleCollapsed || vi.fn()}
+    />
+  );
+};
 
 describe("Signature", () => {
   it("should expand and collapse a function signature", () => {
     const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
-    let collapsed = true;
-    let setCollapsed = () => {
-      collapsed = !collapsed;
-    };
 
-    render(
-      <Signature
-        func={func}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-      />
-    );
+    renderSignature({ func });
 
     expect(screen.findAllByText(func.inputs[0].name!)).resolves.toHaveLength(0);
     act(() => {
@@ -34,18 +35,8 @@ describe("Signature", () => {
 
   it("should render a signature with a void return type", () => {
     const func = buildAbiDefinedFunction();
-    let collapsed = false;
-    let setCollapsed = () => {
-      collapsed = !collapsed;
-    };
 
-    render(
-      <Signature
-        func={func}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-      />
-    );
+    renderSignature({ func });
 
     expect(
       screen.getByRole("heading", { level: 4, name: `${func.name} → void` })
@@ -55,18 +46,8 @@ describe("Signature", () => {
   it("should render a signature with a single return type", () => {
     const outputs = buildOutputList(1);
     const func = buildAbiDefinedFunction({ outputs });
-    let collapsed = false;
-    let setCollapsed = () => {
-      collapsed = !collapsed;
-    };
 
-    render(
-      <Signature
-        func={func}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-      />
-    );
+    renderSignature({ func });
 
     expect(
       screen.getByRole("heading", {
@@ -79,18 +60,8 @@ describe("Signature", () => {
   it("should render a signature with multiple return types", () => {
     const outputs = buildOutputList(2);
     const func = buildAbiDefinedFunction({ outputs });
-    let collapsed = false;
-    let setCollapsed = () => {
-      collapsed = !collapsed;
-    };
 
-    render(
-      <Signature
-        func={func}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-      />
-    );
+    renderSignature({ func });
 
     expect(
       screen.getByRole("heading", {
@@ -104,18 +75,8 @@ describe("Signature", () => {
     const components = buildOutputList(2) as AbiParameterWithComponents[];
     const output = buildOutput({ type: "tuple", components });
     const func = buildAbiDefinedFunction({ outputs: [output] });
-    let collapsed = false;
-    let setCollapsed = () => {
-      collapsed = !collapsed;
-    };
 
-    render(
-      <Signature
-        func={func}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-      />
-    );
+    renderSignature({ func });
 
     expect(
       screen.getByRole("heading", {
@@ -130,18 +91,8 @@ describe("Signature", () => {
     const output = buildOutput({ type: "tuple", components });
     const outputs = [output, ...buildOutputList(2)];
     const func = buildAbiDefinedFunction({ outputs });
-    let collapsed = false;
-    let setCollapsed = () => {
-      collapsed = !collapsed;
-    };
 
-    render(
-      <Signature
-        func={func}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-      />
-    );
+    renderSignature({ func });
 
     expect(
       screen.getByRole("heading", {

--- a/components/function/signature/index.tsx
+++ b/components/function/signature/index.tsx
@@ -1,11 +1,10 @@
 import { MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
-import { Dispatch, SetStateAction } from "react";
 import { AbiDefinedFunction, AbiParameterWithComponents } from "core/types";
 
 type SignatureProps = {
   func: AbiDefinedFunction;
   collapsed: boolean;
-  setCollapsed: Dispatch<SetStateAction<boolean>>;
+  toggleCollapsed: () => void;
 };
 
 const getType = (output: AbiParameterWithComponents): string => {
@@ -28,14 +27,11 @@ const getReturnType = (
 export const Signature = ({
   func,
   collapsed,
-  setCollapsed,
+  toggleCollapsed,
 }: SignatureProps) => {
   const returnType = getReturnType(
     func.outputs as AbiParameterWithComponents[]
   );
-  const handleCollapseToggle = () => {
-    setCollapsed((collapsed) => !collapsed);
-  };
 
   return (
     <div className="flex items-center gap-2">
@@ -47,7 +43,7 @@ export const Signature = ({
       </span>
       <button
         className="inline p-0.5 mx-0.5 rounded-sm text-black dark:text-white focus:bg-black focus:text-white dark:focus:bg-white dark:focus:text-black focus:outline-none"
-        onClick={handleCollapseToggle}
+        onClick={toggleCollapsed}
         data-testid={`signature-toggle-collapse-${func.name}`}
       >
         {collapsed ? (

--- a/components/function/signature/index.tsx
+++ b/components/function/signature/index.tsx
@@ -33,6 +33,10 @@ export const Signature = ({
     func.outputs as AbiParameterWithComponents[]
   );
 
+  const [CollapseIcon, collapseText] = collapsed
+    ? [PlusIcon, "Expand"]
+    : [MinusIcon, "Collapse"];
+
   return (
     <div className="flex items-center gap-2">
       <h4 className="font-bold">
@@ -44,13 +48,9 @@ export const Signature = ({
       <button
         className="inline p-0.5 mx-0.5 rounded-sm text-black dark:text-white focus:bg-black focus:text-white dark:focus:bg-white dark:focus:text-black focus:outline-none"
         onClick={toggleCollapsed}
-        data-testid={`signature-toggle-collapse-${func.name}`}
       >
-        {collapsed ? (
-          <PlusIcon className="h-4 w-4" />
-        ) : (
-          <MinusIcon className="h-4 w-4" />
-        )}
+        <span className="sr-only">{collapseText}</span>
+        <CollapseIcon className="h-4 w-4" />
       </button>
     </div>
   );

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -10,7 +10,6 @@ import {
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { View } from ".";
-import { AbiDefinedFunction } from "../../../core/types";
 import { act } from "@testing-library/react";
 
 vi.mock("wagmi");

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -10,7 +10,6 @@ import {
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { View } from ".";
-import { act } from "@testing-library/react";
 
 vi.mock("wagmi");
 
@@ -24,18 +23,27 @@ useContractReadMock.mockReturnValue({
 });
 
 const renderView = (props: Partial<ComponentProps<typeof View>> = {}) => {
-  const func = props.func || buildAbiDefinedFunction();
-  const view = render(
-    <View address={props.address || buildAddress()} func={func} />
+  return render(
+    <View
+      address={props.address || buildAddress()}
+      func={props.func || buildAbiDefinedFunction()}
+      initialCollapsed={props.initialCollapsed || false}
+    />
   );
-  // Expand all signatures for easier testing
-  act(() => {
-    screen.getByTestId(`signature-toggle-collapse-${func.name}`).click();
-  });
-  return view;
 };
 
 describe("View", () => {
+  it("should not render inputs when initialCollapsed is true", () => {
+    const inputs = buildInputList(2);
+    const func = buildAbiDefinedFunction({ inputs });
+
+    renderView({ func, initialCollapsed: true });
+
+    func.inputs.forEach((input) => {
+      expect(screen.queryByLabelText(input.name!)).not.toBeInTheDocument();
+    });
+  });
+
   it("should render function name", () => {
     const func = buildAbiDefinedFunction();
 

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -16,9 +16,10 @@ import { Signature } from "../signature";
 type ViewProps = {
   address: Address;
   func: AbiDefinedFunction;
+  initialCollapsed: boolean;
 };
 
-export const View = ({ address, func }: ViewProps) => {
+export const View = ({ address, func, initialCollapsed }: ViewProps) => {
   const { args, formattedArgs, updateValue, isTouched } = useArgs(
     func.inputs as AbiParameterWithComponents[]
   );
@@ -33,7 +34,8 @@ export const View = ({ address, func }: ViewProps) => {
     args: formattedArgs,
     watch: true,
   });
-  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
+  const { state: collapsed, toggle: toggleCollapsed } =
+    useToggle(initialCollapsed);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -7,8 +7,7 @@ import {
   Address,
   Result,
 } from "core/types";
-import { useArgs } from "hooks";
-import React from "react";
+import { useArgs, useToggle } from "hooks";
 import { useContractRead } from "wagmi";
 import { Container } from "../container";
 import { Output } from "../output";
@@ -34,14 +33,14 @@ export const View = ({ address, func }: ViewProps) => {
     args: formattedArgs,
     watch: true,
   });
-  const [collapsed, setCollapsed] = React.useState(true);
+  const { state: collapsed, toggle: toggleCollapsed } = useToggle(true);
 
   return (
     <li key={func.name} className="flex flex-col gap-2">
       <Signature
         func={func}
         collapsed={collapsed}
-        setCollapsed={setCollapsed}
+        toggleCollapsed={toggleCollapsed}
       />
 
       {!collapsed && (


### PR DESCRIPTION
## Motivation

React state that can be toggled should leverage the `useToggle` custom hook.

## Solution

Replace the React `useState` hook with the `useToggle` hook.

## Additional Notes

Adding the `initialCollapsed` prop makes for easier testing and will enable a planned feature to configure whether functions are expanded or collapsed by default.