### PR TITLE
deps: upgrade vitest to 0.27.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4",
     "vite": "^4.0.1",
-    "vitest": "^0.25.8"
+    "vitest": "^0.27.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@vitejs/plugin-react": "^3.0.0",
-    "@vitest/coverage-c8": "^0.27.1",
+    "@vitest/coverage-c8": "^0.27.3",
     "abitype": "^0.3.0",
     "autoprefixer": "^10.4.13",
     "eslint": "^8.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,7 +1875,7 @@
     magic-string "^0.27.0"
     react-refresh "^0.14.0"
 
-"@vitest/coverage-c8@^0.27.1":
+"@vitest/coverage-c8@^0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@vitest/coverage-c8/-/coverage-c8-0.27.3.tgz#fef29bd092f06a5a51ec30ce10b26f4ca1fbd41f"
   integrity sha512-xIN4FXXwJqeP6z0gfQ06gbyBMRN2mYvZ4/mn4F96mKXzch0Y93fBeS81eo7D/2YtjbeJBUcU9/amPVb2T+h83Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7803,7 +7803,7 @@ vite-node@0.27.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@0.27.3:
+vitest@0.27.3, vitest@^0.27.3:
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.27.3.tgz#207529ca35943956e3141b270ac01dcc635a89c3"
   integrity sha512-Ld3UVgRVhJUtqvQ3dW89GxiApFAgBsWJZBCWzK+gA3w2yG68csXlGZZ4WDJURf+8ecNfgrScga6xY+8YSOpiMg==
@@ -7827,26 +7827,6 @@ vitest@0.27.3:
     vite "^3.0.0 || ^4.0.0"
     vite-node "0.27.3"
     why-is-node-running "^2.2.2"
-
-vitest@^0.25.8:
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.25.8.tgz#9b57e0b41cd6f2d2d92aa94a39b35c36f715f8cc"
-  integrity sha512-X75TApG2wZTJn299E/TIYevr4E9/nBo1sUtZzn0Ci5oK8qnpZAZyhwg0qCeMSakGIWtc6oRwcQFyFfW14aOFWg==
-  dependencies:
-    "@types/chai" "^4.3.4"
-    "@types/chai-subset" "^1.3.3"
-    "@types/node" "*"
-    acorn "^8.8.1"
-    acorn-walk "^8.2.0"
-    chai "^4.3.7"
-    debug "^4.3.4"
-    local-pkg "^0.4.2"
-    source-map "^0.6.1"
-    strip-literal "^1.0.0"
-    tinybench "^2.3.1"
-    tinypool "^0.3.0"
-    tinyspy "^1.0.2"
-    vite "^3.0.0 || ^4.0.0"
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

- Upgrade `vitest` to 0.27.3
- Upgrade `@vitest/coverage-c8` to 0.27.3