### PR TITLE
deps: upgrade jsdom to 21.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.32.0",
     "eslint-config-next": "^13.1.4",
     "husky": "^8.0.3",
-    "jsdom": "^21.0.0",
+    "jsdom": "^21.1.0",
     "msw": "^0.49.3",
     "node-mocks-http": "^1.12.1",
     "postcss": "^8.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,10 +5292,10 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^21.0.0:
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-21.0.0.tgz#33e22f2fc44286e50ac853c7b7656c8864a4ea45"
-  integrity sha512-AIw+3ZakSUtDYvhwPwWHiZsUi3zHugpMEKlNPaurviseYoBqo0zBd3zqoUi3LPCNtPFlEP8FiW9MqCZdjb2IYA==
+jsdom@^21.1.0:
+  version "21.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-21.1.0.tgz#d56ba4a84ed478260d83bd53dc181775f2d8e6ef"
+  integrity sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==
   dependencies:
     abab "^2.0.6"
     acorn "^8.8.1"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `jsdom` to 21.1.0