### PR TITLE
refactor: replace jest mock with vitest mock

### DIFF
--- a/components/functions/index.test.tsx
+++ b/components/functions/index.test.tsx
@@ -1,12 +1,13 @@
 import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAbiDefinedFunctionList, buildAddress } from "testing/factory";
+import { Mock } from "vitest";
 import { useContractRead, useContractWrite } from "wagmi";
 import { Functions } from ".";
 
 vi.mock("wagmi");
 
-const useContractReadMock = useContractRead as jest.Mock<any>;
+const useContractReadMock = useContractRead as Mock;
 
 useContractReadMock.mockReturnValue({
   data: undefined,
@@ -15,7 +16,7 @@ useContractReadMock.mockReturnValue({
   refetch: vi.fn(),
 });
 
-const useContractWriteMock = useContractWrite as jest.Mock<any>;
+const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
 const renderFunctions = (

--- a/components/wallet/account/index.test.tsx
+++ b/components/wallet/account/index.test.tsx
@@ -1,17 +1,18 @@
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
+import { Mock } from "vitest";
 import { useAccount, useBalance } from "wagmi";
 import { Account } from ".";
 
 vi.mock("wagmi");
 
-const useAccountMock = useAccount as jest.Mock<any>;
+const useAccountMock = useAccount as Mock;
 
 useAccountMock.mockReturnValue({
   address: buildAddress(),
 });
 
-const useBalanceMock = useBalance as jest.Mock<any>;
+const useBalanceMock = useBalance as Mock;
 
 useBalanceMock.mockReturnValue({ data: undefined });
 

--- a/components/wallet/index.test.tsx
+++ b/components/wallet/index.test.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
+import { Mock } from "vitest";
 import {
   useAccount,
   useBalance,
@@ -11,26 +12,25 @@ import { Wallet } from ".";
 
 vi.mock("wagmi");
 
-const usePrepareSendTransactionMock =
-  usePrepareSendTransaction as jest.Mock<any>;
+const usePrepareSendTransactionMock = usePrepareSendTransaction as Mock;
 
 usePrepareSendTransactionMock.mockReturnValue({
   config: {},
 });
 
-const useSendTransactionMock = useSendTransaction as jest.Mock<any>;
+const useSendTransactionMock = useSendTransaction as Mock;
 
 useSendTransactionMock.mockReturnValue({
   sendTransaction: vi.fn(),
 });
 
-const useAccountMock = useAccount as jest.Mock<any>;
+const useAccountMock = useAccount as Mock;
 
 useAccountMock.mockReturnValue({
   address: buildAddress(),
 });
 
-const useBalanceMock = useBalance as jest.Mock<any>;
+const useBalanceMock = useBalance as Mock;
 
 useBalanceMock.mockReturnValue({
   data: undefined,

--- a/components/wallet/transfer/index.test.tsx
+++ b/components/wallet/transfer/index.test.tsx
@@ -1,19 +1,19 @@
 import { faker } from "@faker-js/faker/locale/en";
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
+import { Mock } from "vitest";
 import { usePrepareSendTransaction, useSendTransaction } from "wagmi";
 import { Transfer } from ".";
 
 vi.mock("wagmi");
 
-const usePrepareSendTransactionMock =
-  usePrepareSendTransaction as jest.Mock<any>;
+const usePrepareSendTransactionMock = usePrepareSendTransaction as Mock;
 
 usePrepareSendTransactionMock.mockReturnValue({
   config: {},
 });
 
-const useSendTransactionMock = useSendTransaction as jest.Mock<any>;
+const useSendTransactionMock = useSendTransaction as Mock;
 
 useSendTransactionMock.mockReturnValue({
   sendTransaction: vi.fn(),


### PR DESCRIPTION
## Motivation

The jest `Mock` types should be replaced with the vitest `Mock` type.

## Solution

Replace jest `Mock` types with vitest `Mock` type.