### PR TITLE
deps: upgrade vitest to 0.28.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@vitejs/plugin-react": "^3.0.0",
-    "@vitest/coverage-c8": "^0.28.2",
+    "@vitest/coverage-c8": "^0.28.3",
     "abitype": "^0.3.0",
     "autoprefixer": "^10.4.13",
     "eslint": "^8.32.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4",
     "vite": "^4.0.1",
-    "vitest": "^0.28.2"
+    "vitest": "^0.28.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2999,9 +2999,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426:
-  version "1.0.30001448"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz#ca7550b1587c92a392a2b377cd9c508b3b4395bf"
-  integrity sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA==
+  version "1.0.30001449"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
+  integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
 
 chai@^4.3.7:
   version "4.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,24 +1880,15 @@
     magic-string "^0.27.0"
     react-refresh "^0.14.0"
 
-"@vitest/coverage-c8@^0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-c8/-/coverage-c8-0.28.2.tgz#6fc03502b98102a568a49a357bc3fb41d10933c4"
-  integrity sha512-BWiOUk+d5LvK/9pKaYbL8eLng2EFXgTQMH9QN5nOoizWWKXGNO6LjduVpoz8ZQfb8/6tMVhae7SAS+w0zkRkNw==
+"@vitest/coverage-c8@^0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-c8/-/coverage-c8-0.28.3.tgz#15966a0c0ca2f30a1811d1b695221495307bcc52"
+  integrity sha512-3Toi4flNyxwSSYohhV3/euFSyrHjaD9vJVwFVcy84lcRHMEkv0W7pxlqZZeCvPdktN+WETbNazx3WWBs0jqhVQ==
   dependencies:
     c8 "^7.12.0"
     picocolors "^1.0.0"
     std-env "^3.3.1"
-    vitest "0.28.2"
-
-"@vitest/expect@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-0.28.2.tgz#375af32579b3d6b972a1fe0be0e0260ffb84bc7d"
-  integrity sha512-syEAK7I24/aGR2lXma98WNnvMwAJ+fMx32yPcj8eLdCEWjZI3SH8ozMaKQMy65B/xZCZAl6MXmfjtJb2CpWPMg==
-  dependencies:
-    "@vitest/spy" "0.28.2"
-    "@vitest/utils" "0.28.2"
-    chai "^4.3.7"
+    vitest "0.28.3"
 
 "@vitest/expect@0.28.3":
   version "0.28.3"
@@ -1908,15 +1899,6 @@
     "@vitest/utils" "0.28.3"
     chai "^4.3.7"
 
-"@vitest/runner@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.28.2.tgz#671c8f489ceac2bcf1bc2d993f9920da10347d3f"
-  integrity sha512-BJ9CtfPwWM8uc5p7Ty0OprwApyh8RIaSK7QeQPhwfDYA59AAE009OytqA3aX0yj1Qy5+k/mYFJS8RJZgsueSGA==
-  dependencies:
-    "@vitest/utils" "0.28.2"
-    p-limit "^4.0.0"
-    pathe "^1.1.0"
-
 "@vitest/runner@0.28.3":
   version "0.28.3"
   resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.28.3.tgz#a59bc7a1457957291b6bf1964831284768168314"
@@ -1926,30 +1908,12 @@
     p-limit "^4.0.0"
     pathe "^1.1.0"
 
-"@vitest/spy@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-0.28.2.tgz#74d970601eebc41d48e685323b2853b2c88f8db4"
-  integrity sha512-KlLzTzi5E6tHcI12VT+brlY1Pdi7sUzLf9+YXgh80+CfLu9DqPZi38doBBAUhqEnW/emoLCMinPMMoJlNAQZXA==
-  dependencies:
-    tinyspy "^1.0.2"
-
 "@vitest/spy@0.28.3":
   version "0.28.3"
   resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-0.28.3.tgz#6f6f7ecdeefecb023a96e69b6083e0314ea6f04c"
   integrity sha512-jULA6suS6CCr9VZfr7/9x97pZ0hC55prnUNHNrg5/q16ARBY38RsjsfhuUXt6QOwvIN3BhSS0QqPzyh5Di8g6w==
   dependencies:
     tinyspy "^1.0.2"
-
-"@vitest/utils@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-0.28.2.tgz#2d79de7afb44e821a2c7e692bafb40d2cf765bb7"
-  integrity sha512-wcVTNnVdr22IGxZHDgiXrxWYcXsNg0iX2iBuOH3tVs9eme6fXJ0wxjn0/gCpp0TofQSoUwo3tX8LNACFVseDuA==
-  dependencies:
-    cli-truncate "^3.1.0"
-    diff "^5.1.0"
-    loupe "^2.3.6"
-    picocolors "^1.0.0"
-    pretty-format "^27.5.1"
 
 "@vitest/utils@0.28.3":
   version "0.28.3"
@@ -7580,7 +7544,7 @@ tinybench@^2.3.1:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
   integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
 
-tinypool@^0.3.0, tinypool@^0.3.1:
+tinypool@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.1.tgz#a99c2e446aba9be05d3e1cb756d6aed7af4723b6"
   integrity sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==
@@ -7905,20 +7869,6 @@ valtio@1.9.0:
     proxy-compare "2.4.0"
     use-sync-external-store "1.2.0"
 
-vite-node@0.28.2:
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.2.tgz#58b52fc638f86fee9bfe4990abaea7e4d74f6514"
-  integrity sha512-zyiJ3DLs9zXign4P2MD4PQk+7rdT+JkHukgmmS0KuImbCQ7WnCdea5imQVeT6OtUsBwsLztJxQODUsinVr91tg==
-  dependencies:
-    cac "^6.7.14"
-    debug "^4.3.4"
-    mlly "^1.1.0"
-    pathe "^1.1.0"
-    picocolors "^1.0.0"
-    source-map "^0.6.1"
-    source-map-support "^0.5.21"
-    vite "^3.0.0 || ^4.0.0"
-
 vite-node@0.28.3:
   version "0.28.3"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.3.tgz#5d693c237d5467f167f81d158a56d3408fea899c"
@@ -7945,37 +7895,7 @@ vite-node@0.28.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@0.28.2:
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.28.2.tgz#952e1ad83fbd04ee1bfce634b106a371a5973603"
-  integrity sha512-HJBlRla4Mng0OiZ8aWunCecJ6BzLDA4yuzuxiBuBU2MXjGB6I4zT7QgIBL/UrwGKlNxLwaDC5P/4OpeuTlW8yQ==
-  dependencies:
-    "@types/chai" "^4.3.4"
-    "@types/chai-subset" "^1.3.3"
-    "@types/node" "*"
-    "@vitest/expect" "0.28.2"
-    "@vitest/runner" "0.28.2"
-    "@vitest/spy" "0.28.2"
-    "@vitest/utils" "0.28.2"
-    acorn "^8.8.1"
-    acorn-walk "^8.2.0"
-    cac "^6.7.14"
-    chai "^4.3.7"
-    debug "^4.3.4"
-    local-pkg "^0.4.2"
-    pathe "^1.1.0"
-    picocolors "^1.0.0"
-    source-map "^0.6.1"
-    std-env "^3.3.1"
-    strip-literal "^1.0.0"
-    tinybench "^2.3.1"
-    tinypool "^0.3.0"
-    tinyspy "^1.0.2"
-    vite "^3.0.0 || ^4.0.0"
-    vite-node "0.28.2"
-    why-is-node-running "^2.2.2"
-
-vitest@^0.28.3:
+vitest@0.28.3, vitest@^0.28.3:
   version "0.28.3"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.28.3.tgz#58322a5ae64854d4cdb75451817b9fb795f9102e"
   integrity sha512-N41VPNf3VGJlWQizGvl1P5MGyv3ZZA2Zvh+2V8L6tYBAAuqqDK4zExunT1Cdb6dGfZ4gr+IMrnG8d4Z6j9ctPw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,12 +1899,30 @@
     "@vitest/utils" "0.28.2"
     chai "^4.3.7"
 
+"@vitest/expect@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-0.28.3.tgz#8cd570b662e709f56ba29835879890c87429a194"
+  integrity sha512-dnxllhfln88DOvpAK1fuI7/xHwRgTgR4wdxHldPaoTaBu6Rh9zK5b//v/cjTkhOfNP/AJ8evbNO8H7c3biwd1g==
+  dependencies:
+    "@vitest/spy" "0.28.3"
+    "@vitest/utils" "0.28.3"
+    chai "^4.3.7"
+
 "@vitest/runner@0.28.2":
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.28.2.tgz#671c8f489ceac2bcf1bc2d993f9920da10347d3f"
   integrity sha512-BJ9CtfPwWM8uc5p7Ty0OprwApyh8RIaSK7QeQPhwfDYA59AAE009OytqA3aX0yj1Qy5+k/mYFJS8RJZgsueSGA==
   dependencies:
     "@vitest/utils" "0.28.2"
+    p-limit "^4.0.0"
+    pathe "^1.1.0"
+
+"@vitest/runner@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.28.3.tgz#a59bc7a1457957291b6bf1964831284768168314"
+  integrity sha512-P0qYbATaemy1midOLkw7qf8jraJszCoEvjQOSlseiXZyEDaZTZ50J+lolz2hWiWv6RwDu1iNseL9XLsG0Jm2KQ==
+  dependencies:
+    "@vitest/utils" "0.28.3"
     p-limit "^4.0.0"
     pathe "^1.1.0"
 
@@ -1915,10 +1933,28 @@
   dependencies:
     tinyspy "^1.0.2"
 
+"@vitest/spy@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-0.28.3.tgz#6f6f7ecdeefecb023a96e69b6083e0314ea6f04c"
+  integrity sha512-jULA6suS6CCr9VZfr7/9x97pZ0hC55prnUNHNrg5/q16ARBY38RsjsfhuUXt6QOwvIN3BhSS0QqPzyh5Di8g6w==
+  dependencies:
+    tinyspy "^1.0.2"
+
 "@vitest/utils@0.28.2":
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-0.28.2.tgz#2d79de7afb44e821a2c7e692bafb40d2cf765bb7"
   integrity sha512-wcVTNnVdr22IGxZHDgiXrxWYcXsNg0iX2iBuOH3tVs9eme6fXJ0wxjn0/gCpp0TofQSoUwo3tX8LNACFVseDuA==
+  dependencies:
+    cli-truncate "^3.1.0"
+    diff "^5.1.0"
+    loupe "^2.3.6"
+    picocolors "^1.0.0"
+    pretty-format "^27.5.1"
+
+"@vitest/utils@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-0.28.3.tgz#75c076d4fdde5c48ee5de2808c83d615fc74d4ef"
+  integrity sha512-YHiQEHQqXyIbhDqETOJUKx9/psybF7SFFVCNfOvap0FvyUqbzTSDCa3S5lL4C0CLXkwVZttz9xknDoyHMguFRQ==
   dependencies:
     cli-truncate "^3.1.0"
     diff "^5.1.0"
@@ -7544,7 +7580,7 @@ tinybench@^2.3.1:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
   integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
 
-tinypool@^0.3.0:
+tinypool@^0.3.0, tinypool@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.1.tgz#a99c2e446aba9be05d3e1cb756d6aed7af4723b6"
   integrity sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==
@@ -7883,6 +7919,20 @@ vite-node@0.28.2:
     source-map-support "^0.5.21"
     vite "^3.0.0 || ^4.0.0"
 
+vite-node@0.28.3:
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.3.tgz#5d693c237d5467f167f81d158a56d3408fea899c"
+  integrity sha512-uJJAOkgVwdfCX8PUQhqLyDOpkBS5+j+FdbsXoPVPDlvVjRkb/W/mLYQPSL6J+t8R0UV8tJSe8c9VyxVQNsDSyg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    mlly "^1.1.0"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
+    source-map "^0.6.1"
+    source-map-support "^0.5.21"
+    vite "^3.0.0 || ^4.0.0"
+
 "vite@^3.0.0 || ^4.0.0", vite@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.0.4.tgz#4612ce0b47bbb233a887a54a4ae0c6e240a0da31"
@@ -7895,7 +7945,7 @@ vite-node@0.28.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@0.28.2, vitest@^0.28.2:
+vitest@0.28.2:
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.28.2.tgz#952e1ad83fbd04ee1bfce634b106a371a5973603"
   integrity sha512-HJBlRla4Mng0OiZ8aWunCecJ6BzLDA4yuzuxiBuBU2MXjGB6I4zT7QgIBL/UrwGKlNxLwaDC5P/4OpeuTlW8yQ==
@@ -7923,6 +7973,36 @@ vitest@0.28.2, vitest@^0.28.2:
     tinyspy "^1.0.2"
     vite "^3.0.0 || ^4.0.0"
     vite-node "0.28.2"
+    why-is-node-running "^2.2.2"
+
+vitest@^0.28.3:
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.28.3.tgz#58322a5ae64854d4cdb75451817b9fb795f9102e"
+  integrity sha512-N41VPNf3VGJlWQizGvl1P5MGyv3ZZA2Zvh+2V8L6tYBAAuqqDK4zExunT1Cdb6dGfZ4gr+IMrnG8d4Z6j9ctPw==
+  dependencies:
+    "@types/chai" "^4.3.4"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    "@vitest/expect" "0.28.3"
+    "@vitest/runner" "0.28.3"
+    "@vitest/spy" "0.28.3"
+    "@vitest/utils" "0.28.3"
+    acorn "^8.8.1"
+    acorn-walk "^8.2.0"
+    cac "^6.7.14"
+    chai "^4.3.7"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
+    source-map "^0.6.1"
+    std-env "^3.3.1"
+    strip-literal "^1.0.0"
+    tinybench "^2.3.1"
+    tinypool "^0.3.1"
+    tinyspy "^1.0.2"
+    vite "^3.0.0 || ^4.0.0"
+    vite-node "0.28.3"
     why-is-node-running "^2.2.2"
 
 w3c-xmlserializer@^4.0.0:


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

- Upgrade `vitest` to 0.28.3
- Upgrade `@vitest/coverage-c8` to 0.28.3

## Additional Notes

- Update transitive dependencies 