### PR TITLE
test: add function state helpers

### DIFF
--- a/components/contract/index.tsx
+++ b/components/contract/index.tsx
@@ -2,13 +2,15 @@ import { Square2StackIcon } from "@heroicons/react/24/outline";
 import { Balance } from "components/balance";
 import { Functions } from "components/functions";
 import { AddressZero } from "core/constants";
-import { Abi, AbiDefinedFunction, Address } from "core/types";
+import { Abi, AbiDefinedStateFunction, Address } from "core/types";
 import { useContracts } from "hooks";
 import { Manager } from "./manager";
 import { Setup } from "./setup";
 
-const filterDefinedFunctions = (abi: Abi): AbiDefinedFunction[] => {
-  return abi.filter(({ type }) => type === "function") as AbiDefinedFunction[];
+const filterDefinedFunctions = (abi: Abi): AbiDefinedStateFunction[] => {
+  return abi.filter(
+    ({ type }) => type === "function"
+  ) as AbiDefinedStateFunction[];
 };
 
 const Introduction = () => (

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -1,4 +1,4 @@
-import { AbiDefinedFunction, Address } from "core/types";
+import { AbiDefinedStateFunction, Address } from "core/types";
 import { Nonpayable } from "./nonpayable";
 import { Payable } from "./payable";
 import { Pure } from "./pure";
@@ -6,7 +6,7 @@ import { View } from "./view";
 
 type FunctionProps = {
   address: Address;
-  func: AbiDefinedFunction;
+  func: AbiDefinedStateFunction;
 };
 
 export const Function = ({ address, func }: FunctionProps) => {

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
-  buildAbiDefinedFunction,
+  buildAbiDefinedNonpayableFunction,
   buildAddress,
   buildInput,
   buildInputList,
@@ -23,7 +23,7 @@ const renderNonpayable = (
   return render(
     <Nonpayable
       address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
+      func={props.func || buildAbiDefinedNonpayableFunction()}
       initialCollapsed={props.initialCollapsed || false}
     />
   );
@@ -32,7 +32,7 @@ const renderNonpayable = (
 describe("Nonpayable", () => {
   it("should not render inputs when initialCollapsed is true", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedNonpayableFunction({ inputs });
 
     renderNonpayable({ func, initialCollapsed: true });
 
@@ -42,7 +42,7 @@ describe("Nonpayable", () => {
   });
 
   it("should render function name", () => {
-    const func = buildAbiDefinedFunction();
+    const func = buildAbiDefinedNonpayableFunction();
 
     renderNonpayable({ func });
 
@@ -51,7 +51,7 @@ describe("Nonpayable", () => {
 
   it("should render function inputs", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedNonpayableFunction({ inputs });
 
     renderNonpayable({ func });
 
@@ -89,7 +89,9 @@ describe("Nonpayable", () => {
 
   it("should prepare contract write with provided arguments", async () => {
     const address = buildAddress();
-    const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
+    const func = buildAbiDefinedNonpayableFunction({
+      inputs: buildInputList(2),
+    });
 
     const { user } = renderNonpayable({ address, func });
 
@@ -114,7 +116,9 @@ describe("Nonpayable", () => {
     const address = buildAddress();
     const input1 = buildInput({ type: "uint256" });
     const input2 = buildInput({ type: "uint256" });
-    const func = buildAbiDefinedFunction({ inputs: [input1, input2] });
+    const func = buildAbiDefinedNonpayableFunction({
+      inputs: [input1, input2],
+    });
 
     const { user } = renderNonpayable({ address, func });
 

--- a/components/function/nonpayable/index.tsx
+++ b/components/function/nonpayable/index.tsx
@@ -2,7 +2,7 @@ import { Button } from "components/button";
 import { Inputs } from "components/inputs";
 import {
   Abi,
-  AbiDefinedFunction,
+  AbiDefinedNonpayableFunction,
   AbiParameterWithComponents,
   Address,
 } from "core/types";
@@ -14,7 +14,7 @@ import { Signature } from "../signature";
 
 type NonpayableProps = {
   address: Address;
-  func: AbiDefinedFunction;
+  func: AbiDefinedNonpayableFunction;
   initialCollapsed: boolean;
 };
 

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
-  buildAbiDefinedFunction,
+  buildAbiDefinedPayableFunction,
   buildAddress,
   buildInput,
   buildInputList,
@@ -21,7 +21,7 @@ const renderPayable = (props: Partial<ComponentProps<typeof Payable>> = {}) => {
   return render(
     <Payable
       address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
+      func={props.func || buildAbiDefinedPayableFunction()}
       initialCollapsed={props.initialCollapsed || false}
     />
   );
@@ -30,7 +30,7 @@ const renderPayable = (props: Partial<ComponentProps<typeof Payable>> = {}) => {
 describe("Payable", () => {
   it("should not render inputs when initialCollapsed is true", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedPayableFunction({ inputs });
 
     renderPayable({ func, initialCollapsed: true });
 
@@ -40,7 +40,7 @@ describe("Payable", () => {
   });
 
   it("should render function name", () => {
-    const func = buildAbiDefinedFunction();
+    const func = buildAbiDefinedPayableFunction();
 
     renderPayable({ func });
 
@@ -49,7 +49,7 @@ describe("Payable", () => {
 
   it("should render function inputs", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedPayableFunction({ inputs });
 
     renderPayable({ func });
 
@@ -87,7 +87,7 @@ describe("Payable", () => {
 
   it("should prepare contract write with provided arguments", async () => {
     const address = buildAddress();
-    const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
+    const func = buildAbiDefinedPayableFunction({ inputs: buildInputList(2) });
 
     const { user } = renderPayable({ address, func });
 
@@ -115,7 +115,7 @@ describe("Payable", () => {
     const address = buildAddress();
     const input1 = buildInput({ type: "uint256" });
     const input2 = buildInput({ type: "uint256" });
-    const func = buildAbiDefinedFunction({ inputs: [input1, input2] });
+    const func = buildAbiDefinedPayableFunction({ inputs: [input1, input2] });
 
     const { user } = renderPayable({ address, func });
 
@@ -144,7 +144,7 @@ describe("Payable", () => {
 
   it("should prepare contract with formatted value based on the selected unit", async () => {
     const address = buildAddress();
-    const func = buildAbiDefinedFunction();
+    const func = buildAbiDefinedPayableFunction();
 
     const { user } = renderPayable({ address, func });
 

--- a/components/function/payable/index.tsx
+++ b/components/function/payable/index.tsx
@@ -4,7 +4,7 @@ import { Inputs } from "components/inputs";
 import { Listbox } from "components/listbox";
 import {
   Abi,
-  AbiDefinedFunction,
+  AbiDefinedPayableFunction,
   AbiParameterWithComponents,
   Address,
 } from "core/types";
@@ -16,7 +16,7 @@ import { Signature } from "../signature";
 
 type PayableProps = {
   address: Address;
-  func: AbiDefinedFunction;
+  func: AbiDefinedPayableFunction;
   initialCollapsed: boolean;
 };
 

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
-  buildAbiDefinedFunction,
+  buildAbiDefinedPureFunction,
   buildAddress,
   buildInput,
   buildInputList,
@@ -26,7 +26,7 @@ const renderPure = (props: Partial<ComponentProps<typeof Pure>> = {}) => {
   return render(
     <Pure
       address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
+      func={props.func || buildAbiDefinedPureFunction()}
       initialCollapsed={props.initialCollapsed || false}
     />
   );
@@ -35,7 +35,7 @@ const renderPure = (props: Partial<ComponentProps<typeof Pure>> = {}) => {
 describe("Pure", () => {
   it("should not render inputs when initialCollapsed is true", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedPureFunction({ inputs });
 
     renderPure({ func, initialCollapsed: true });
 
@@ -45,7 +45,7 @@ describe("Pure", () => {
   });
 
   it("should render function name", () => {
-    const func = buildAbiDefinedFunction();
+    const func = buildAbiDefinedPureFunction();
 
     renderPure({ func });
 
@@ -54,7 +54,7 @@ describe("Pure", () => {
 
   it("should render function inputs", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedPureFunction({ inputs });
 
     renderPure({ func });
 
@@ -121,7 +121,7 @@ describe("Pure", () => {
 
   it("should call contract read with provided arguments", async () => {
     const address = buildAddress();
-    const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
+    const func = buildAbiDefinedPureFunction({ inputs: buildInputList(2) });
 
     const { user } = renderPure({ address, func });
 
@@ -146,7 +146,7 @@ describe("Pure", () => {
     const address = buildAddress();
     const input1 = buildInput({ type: "uint256" });
     const input2 = buildInput({ type: "uint256" });
-    const func = buildAbiDefinedFunction({ inputs: [input1, input2] });
+    const func = buildAbiDefinedPureFunction({ inputs: [input1, input2] });
 
     const { user } = renderPure({ address, func });
 

--- a/components/function/pure/index.tsx
+++ b/components/function/pure/index.tsx
@@ -2,7 +2,7 @@ import { Button } from "components/button";
 import { Inputs } from "components/inputs";
 import {
   Abi,
-  AbiDefinedFunction,
+  AbiDefinedPureFunction,
   AbiParameterWithComponents,
   Address,
   Result,
@@ -15,7 +15,7 @@ import { Signature } from "../signature";
 
 type PureProps = {
   address: Address;
-  func: AbiDefinedFunction;
+  func: AbiDefinedPureFunction;
   initialCollapsed: boolean;
 };
 

--- a/components/function/signature/index.tsx
+++ b/components/function/signature/index.tsx
@@ -1,8 +1,11 @@
 import { MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
-import { AbiDefinedFunction, AbiParameterWithComponents } from "core/types";
+import {
+  AbiDefinedStateFunction,
+  AbiParameterWithComponents,
+} from "core/types";
 
 type SignatureProps = {
-  func: AbiDefinedFunction;
+  func: AbiDefinedStateFunction;
   collapsed: boolean;
   toggleCollapsed: () => void;
 };

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
-  buildAbiDefinedFunction,
+  buildAbiDefinedViewFunction,
   buildAddress,
   buildInput,
   buildInputList,
@@ -26,7 +26,7 @@ const renderView = (props: Partial<ComponentProps<typeof View>> = {}) => {
   return render(
     <View
       address={props.address || buildAddress()}
-      func={props.func || buildAbiDefinedFunction()}
+      func={props.func || buildAbiDefinedViewFunction()}
       initialCollapsed={props.initialCollapsed || false}
     />
   );
@@ -35,7 +35,7 @@ const renderView = (props: Partial<ComponentProps<typeof View>> = {}) => {
 describe("View", () => {
   it("should not render inputs when initialCollapsed is true", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedViewFunction({ inputs });
 
     renderView({ func, initialCollapsed: true });
 
@@ -45,7 +45,7 @@ describe("View", () => {
   });
 
   it("should render function name", () => {
-    const func = buildAbiDefinedFunction();
+    const func = buildAbiDefinedViewFunction();
 
     renderView({ func });
 
@@ -54,7 +54,7 @@ describe("View", () => {
 
   it("should render function inputs", () => {
     const inputs = buildInputList(2);
-    const func = buildAbiDefinedFunction({ inputs });
+    const func = buildAbiDefinedViewFunction({ inputs });
 
     renderView({ func });
 
@@ -121,7 +121,7 @@ describe("View", () => {
 
   it("should call contract read with provided arguments", async () => {
     const address = buildAddress();
-    const func = buildAbiDefinedFunction({ inputs: buildInputList(2) });
+    const func = buildAbiDefinedViewFunction({ inputs: buildInputList(2) });
 
     const { user } = renderView({ address, func });
 
@@ -146,7 +146,7 @@ describe("View", () => {
     const address = buildAddress();
     const input1 = buildInput({ type: "uint256" });
     const input2 = buildInput({ type: "uint256" });
-    const func = buildAbiDefinedFunction({ inputs: [input1, input2] });
+    const func = buildAbiDefinedViewFunction({ inputs: [input1, input2] });
 
     const { user } = renderView({ address, func });
 

--- a/components/function/view/index.tsx
+++ b/components/function/view/index.tsx
@@ -2,7 +2,7 @@ import { Button } from "components/button";
 import { Inputs } from "components/inputs";
 import {
   Abi,
-  AbiDefinedFunction,
+  AbiDefinedViewFunction,
   AbiParameterWithComponents,
   Address,
   Result,
@@ -15,7 +15,7 @@ import { Signature } from "../signature";
 
 type ViewProps = {
   address: Address;
-  func: AbiDefinedFunction;
+  func: AbiDefinedViewFunction;
   initialCollapsed: boolean;
 };
 

--- a/components/functions/index.tsx
+++ b/components/functions/index.tsx
@@ -1,9 +1,9 @@
-import { AbiDefinedFunction, Address } from "core/types";
+import { AbiDefinedStateFunction, Address } from "core/types";
 import { Function } from "components/function";
 
 type FunctionsProps = {
   address: Address;
-  functions: AbiDefinedFunction[];
+  functions: AbiDefinedStateFunction[];
 };
 
 export const Functions = ({ address, functions }: FunctionsProps) => {

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -10,13 +10,35 @@ export type Arg = {
   isTouched: boolean;
 };
 
-export type AbiDefinedFunction = {
+type AbiDefinedFunction = {
   inputs: readonly AbiParameter[];
   name: string;
   outputs: readonly AbiParameter[];
   stateMutability: AbiStateMutability;
   type: "function";
 };
+
+export type AbiDefinedNonpayableFunction = AbiDefinedFunction & {
+  stateMutability: "nonpayable";
+};
+
+export type AbiDefinedPayableFunction = AbiDefinedFunction & {
+  stateMutability: "payable";
+};
+
+export type AbiDefinedPureFunction = AbiDefinedFunction & {
+  stateMutability: "pure";
+};
+
+export type AbiDefinedViewFunction = AbiDefinedFunction & {
+  stateMutability: "view";
+};
+
+export type AbiDefinedStateFunction =
+  | AbiDefinedNonpayableFunction
+  | AbiDefinedPayableFunction
+  | AbiDefinedPureFunction
+  | AbiDefinedViewFunction;
 
 export type AbiParameterWithComponents = AbiParameter & {
   components?: AbiParameterWithComponents[];

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -73,6 +73,13 @@ export const buildAbiDefinedFunction = (
     faker.helpers.arrayElement(["view", "pure", "nonpayable", "payable"]),
 });
 
+export const buildAbiDefinedNonpayableFunction = (
+  overrides: Partial<AbiDefinedFunction> = {}
+): AbiDefinedFunction => ({
+  ...buildAbiDefinedFunction(overrides),
+  stateMutability: "nonpayable",
+});
+
 export const buildAbiDefinedPureFunction = (
   overrides: Partial<AbiDefinedFunction> = {}
 ): AbiDefinedFunction => ({

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -1,5 +1,9 @@
 import {
-  AbiDefinedFunction,
+  AbiDefinedNonpayableFunction,
+  AbiDefinedPayableFunction,
+  AbiDefinedPureFunction,
+  AbiDefinedStateFunction,
+  AbiDefinedViewFunction,
   AbiError,
   AbiEvent,
   AbiParameter,
@@ -58,8 +62,8 @@ export const buildContractDetailsList = (n: number): ContractDetails[] =>
   times(n, () => buildContractDetails());
 
 export const buildAbiDefinedFunction = (
-  overrides: Partial<AbiDefinedFunction> = {}
-): AbiDefinedFunction => ({
+  overrides: Partial<AbiDefinedStateFunction> = {}
+): AbiDefinedStateFunction => ({
   name:
     overrides.name ||
     faker.helpers.unique(faker.word.noun, undefined, {
@@ -74,35 +78,36 @@ export const buildAbiDefinedFunction = (
 });
 
 export const buildAbiDefinedNonpayableFunction = (
-  overrides: Partial<AbiDefinedFunction> = {}
-): AbiDefinedFunction => ({
+  overrides: Partial<AbiDefinedNonpayableFunction> = {}
+): AbiDefinedNonpayableFunction => ({
   ...buildAbiDefinedFunction(overrides),
   stateMutability: "nonpayable",
 });
 
 export const buildAbiDefinedPayableFunction = (
-  overrides: Partial<AbiDefinedFunction> = {}
-): AbiDefinedFunction => ({
+  overrides: Partial<AbiDefinedPayableFunction> = {}
+): AbiDefinedPayableFunction => ({
   ...buildAbiDefinedFunction(overrides),
   stateMutability: "payable",
 });
 
 export const buildAbiDefinedPureFunction = (
-  overrides: Partial<AbiDefinedFunction> = {}
-): AbiDefinedFunction => ({
+  overrides: Partial<AbiDefinedPureFunction> = {}
+): AbiDefinedPureFunction => ({
   ...buildAbiDefinedFunction(overrides),
   stateMutability: "pure",
 });
 
 export const buildAbiDefinedViewFunction = (
-  overrides: Partial<AbiDefinedFunction> = {}
-): AbiDefinedFunction => ({
+  overrides: Partial<AbiDefinedViewFunction> = {}
+): AbiDefinedViewFunction => ({
   ...buildAbiDefinedFunction(overrides),
   stateMutability: "view",
 });
 
-export const buildAbiDefinedFunctionList = (n: number): AbiDefinedFunction[] =>
-  times(n, () => buildAbiDefinedFunction());
+export const buildAbiDefinedFunctionList = (
+  n: number
+): AbiDefinedStateFunction[] => times(n, () => buildAbiDefinedFunction());
 
 export const buildInput = (
   overrides: Partial<AbiParameter> = {}

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -80,6 +80,13 @@ export const buildAbiDefinedNonpayableFunction = (
   stateMutability: "nonpayable",
 });
 
+export const buildAbiDefinedPayableFunction = (
+  overrides: Partial<AbiDefinedFunction> = {}
+): AbiDefinedFunction => ({
+  ...buildAbiDefinedFunction(overrides),
+  stateMutability: "payable",
+});
+
 export const buildAbiDefinedPureFunction = (
   overrides: Partial<AbiDefinedFunction> = {}
 ): AbiDefinedFunction => ({

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -94,6 +94,13 @@ export const buildAbiDefinedPureFunction = (
   stateMutability: "pure",
 });
 
+export const buildAbiDefinedViewFunction = (
+  overrides: Partial<AbiDefinedFunction> = {}
+): AbiDefinedFunction => ({
+  ...buildAbiDefinedFunction(overrides),
+  stateMutability: "view",
+});
+
 export const buildAbiDefinedFunctionList = (n: number): AbiDefinedFunction[] =>
   times(n, () => buildAbiDefinedFunction());
 

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -73,6 +73,13 @@ export const buildAbiDefinedFunction = (
     faker.helpers.arrayElement(["view", "pure", "nonpayable", "payable"]),
 });
 
+export const buildAbiDefinedPureFunction = (
+  overrides: Partial<AbiDefinedFunction> = {}
+): AbiDefinedFunction => ({
+  ...buildAbiDefinedFunction(overrides),
+  stateMutability: "pure",
+});
+
 export const buildAbiDefinedFunctionList = (n: number): AbiDefinedFunction[] =>
   times(n, () => buildAbiDefinedFunction());
 


### PR DESCRIPTION
## Motivation

The `buildAbiDefinedFunction` test helper randomly generates a `stateMutability` value of "nonpayable", "payable", "pure", or "view". This test helper was being used in tests that expect a specific `stateMutability` value without specifying the correct override value to the helper.

## Solution

Test helpers were added for each of the state mutability function types.

## Additional Notes

Stricter types were added to components that render ABI functions with a specific state mutability type to help prevent misuse and confusion in tests and production code.