### PR TITLE
test: add partial prop type helper

### DIFF
--- a/components/balance/index.test.tsx
+++ b/components/balance/index.test.tsx
@@ -1,6 +1,6 @@
-import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
+import { PartialProps } from "testing/types";
 import type { Mock } from "vitest";
 import { useBalance } from "wagmi";
 import { Balance } from ".";
@@ -15,7 +15,7 @@ useBalanceMock.mockReturnValue({
   isError: false,
 });
 
-const renderBalance = (props: Partial<ComponentProps<typeof Balance>> = {}) => {
+const renderBalance = (props: PartialProps<typeof Balance> = {}) => {
   return render(<Balance address={props.address || buildAddress()} />);
 };
 

--- a/components/contract/index.test.tsx
+++ b/components/contract/index.test.tsx
@@ -1,7 +1,6 @@
 import { AddressZero } from "core/constants";
 import { server } from "mocks/server";
 import { rest } from "msw";
-import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
   buildAbiDefinedFunction,
@@ -12,6 +11,7 @@ import {
   buildContractDetails,
   buildContractDetailsList,
 } from "testing/factory";
+import { PartialProps } from "testing/types";
 import type { Mock } from "vitest";
 import { useBalance, useContractRead, useContractWrite } from "wagmi";
 import { Contract } from ".";
@@ -38,9 +38,7 @@ useBalanceMock.mockReturnValue({
 const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
-const renderContract = (
-  props: Partial<ComponentProps<typeof Contract>> = {}
-) => {
+const renderContract = (props: PartialProps<typeof Contract> = {}) => {
   return render(<Contract address={props.address || buildAddress()} />);
 };
 

--- a/components/contracts/index.test.tsx
+++ b/components/contracts/index.test.tsx
@@ -1,14 +1,12 @@
 import { AddressZero } from "core/constants";
 import { server } from "mocks/server";
 import { rest } from "msw";
-import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildContractDetailsList } from "testing/factory";
+import { PartialProps } from "testing/types";
 import { Contracts } from ".";
 
-const renderContracts = (
-  props: Partial<ComponentProps<typeof Contracts>> = {}
-) => {
+const renderContracts = (props: PartialProps<typeof Contracts> = {}) => {
   const activeContract = AddressZero;
   const setActiveContract = vi.fn();
   return render(

--- a/components/field/index.test.tsx
+++ b/components/field/index.test.tsx
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker/locale/en";
-import { ComponentProps } from "react";
 import { render, screen } from "testing";
+import { PartialProps } from "testing/types";
 import { Field } from ".";
 
-const renderField = (props: Partial<ComponentProps<typeof Field>> = {}) => {
+const renderField = (props: PartialProps<typeof Field> = {}) => {
   return render(
     <Field
       handleChange={props.handleChange || vi.fn()}

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from "ethers";
-import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
   buildAbiDefinedNonpayableFunction,
@@ -8,6 +7,7 @@ import {
   buildInputList,
   buildTransactionHash,
 } from "testing/factory";
+import { PartialProps } from "testing/types";
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
 import { Nonpayable } from ".";
@@ -17,9 +17,7 @@ vi.mock("wagmi");
 const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
-const renderNonpayable = (
-  props: Partial<ComponentProps<typeof Nonpayable>> = {}
-) => {
+const renderNonpayable = (props: PartialProps<typeof Nonpayable> = {}) => {
   return render(
     <Nonpayable
       address={props.address || buildAddress()}

--- a/components/function/output/index.test.tsx
+++ b/components/function/output/index.test.tsx
@@ -1,10 +1,10 @@
 import { BigNumber } from "ethers";
-import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildResult } from "testing/factory";
+import { PartialProps } from "testing/types";
 import { Output } from ".";
 
-const renderOutput = (props: Partial<ComponentProps<typeof Output>> = {}) =>
+const renderOutput = (props: PartialProps<typeof Output> = {}) =>
   render(
     <Output
       data={props.data || undefined}

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from "ethers";
-import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
   buildAbiDefinedPayableFunction,
@@ -8,6 +7,7 @@ import {
   buildInputList,
   buildTransactionHash,
 } from "testing/factory";
+import { PartialProps } from "testing/types";
 import type { Mock } from "vitest";
 import { useContractWrite } from "wagmi";
 import { Payable } from ".";
@@ -17,7 +17,7 @@ vi.mock("wagmi");
 const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
-const renderPayable = (props: Partial<ComponentProps<typeof Payable>> = {}) => {
+const renderPayable = (props: PartialProps<typeof Payable> = {}) => {
   return render(
     <Payable
       address={props.address || buildAddress()}

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from "ethers";
-import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
   buildAbiDefinedPureFunction,
@@ -7,6 +6,7 @@ import {
   buildInput,
   buildInputList,
 } from "testing/factory";
+import { PartialProps } from "testing/types";
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { Pure } from ".";
@@ -22,7 +22,7 @@ useContractReadMock.mockReturnValue({
   refetch: vi.fn(),
 });
 
-const renderPure = (props: Partial<ComponentProps<typeof Pure>> = {}) => {
+const renderPure = (props: PartialProps<typeof Pure> = {}) => {
   return render(
     <Pure
       address={props.address || buildAddress()}

--- a/components/function/signature/index.test.tsx
+++ b/components/function/signature/index.test.tsx
@@ -6,10 +6,10 @@ import {
   buildOutput,
   buildOutputList,
 } from "testing/factory";
+import { PartialProps } from "testing/types";
 import { Signature } from ".";
-import { ComponentProps } from "react";
 
-const renderSignature = (props: Partial<ComponentProps<typeof Signature>>) => {
+const renderSignature = (props: PartialProps<typeof Signature>) => {
   return render(
     <Signature
       func={props.func || buildAbiDefinedFunction()}

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from "ethers";
-import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import {
   buildAbiDefinedViewFunction,
@@ -7,6 +6,7 @@ import {
   buildInput,
   buildInputList,
 } from "testing/factory";
+import { PartialProps } from "testing/types";
 import type { Mock } from "vitest";
 import { useContractRead } from "wagmi";
 import { View } from ".";
@@ -22,7 +22,7 @@ useContractReadMock.mockReturnValue({
   refetch: vi.fn(),
 });
 
-const renderView = (props: Partial<ComponentProps<typeof View>> = {}) => {
+const renderView = (props: PartialProps<typeof View> = {}) => {
   return render(
     <View
       address={props.address || buildAddress()}

--- a/components/functions/index.test.tsx
+++ b/components/functions/index.test.tsx
@@ -1,6 +1,6 @@
-import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAbiDefinedFunctionList, buildAddress } from "testing/factory";
+import { PartialProps } from "testing/types";
 import { Mock } from "vitest";
 import { useContractRead, useContractWrite } from "wagmi";
 import { Functions } from ".";
@@ -19,9 +19,7 @@ useContractReadMock.mockReturnValue({
 const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
-const renderFunctions = (
-  props: Partial<ComponentProps<typeof Functions>> = {}
-) => {
+const renderFunctions = (props: PartialProps<typeof Functions> = {}) => {
   return render(
     <Functions
       address={props.address || buildAddress()}

--- a/components/inputs/index.test.tsx
+++ b/components/inputs/index.test.tsx
@@ -1,9 +1,9 @@
-import { ComponentProps } from "react";
 import { render, screen, waitFor } from "testing";
 import { buildArg, buildArgList } from "testing/factory";
+import { PartialProps } from "testing/types";
 import { Inputs } from ".";
 
-const renderInputs = (props: Partial<ComponentProps<typeof Inputs>>) => {
+const renderInputs = (props: PartialProps<typeof Inputs>) => {
   return render(
     <Inputs
       name={props.name || ""}

--- a/components/wallet/index.test.tsx
+++ b/components/wallet/index.test.tsx
@@ -1,6 +1,6 @@
-import { ComponentProps } from "react";
 import { render, screen } from "testing";
 import { buildAddress } from "testing/factory";
+import { PartialProps } from "testing/types";
 import { Mock } from "vitest";
 import {
   useAccount,
@@ -36,7 +36,7 @@ useBalanceMock.mockReturnValue({
   data: undefined,
 });
 
-const renderWallet = (props: Partial<ComponentProps<typeof Wallet>> = {}) => {
+const renderWallet = (props: PartialProps<typeof Wallet> = {}) => {
   return render(<Wallet open={props.open || false} />);
 };
 

--- a/testing/types.ts
+++ b/testing/types.ts
@@ -1,0 +1,5 @@
+import { ComponentProps, JSXElementConstructor } from "react";
+
+export type PartialProps<
+  T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+> = Partial<ComponentProps<T>>;


### PR DESCRIPTION
## Motivation

Duplicate `Partial<ComponentProps<typeof *>>` should be extracted into a custom type.

## Solution

Add a custom `PartialProps` type.