### PR TITLE
chore: add test watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepare": "husky install",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Motivation

Blacksmith should include a way for tests to easily be run in watch mode.

## Solution

Add script for running tests in watch mode.