### PR TITLE
deps: upgrade typescript to 4.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "postcss": "^8.4.21",
     "prettier": "2.8.3",
     "tailwindcss": "^3.2.4",
-    "typescript": "^4.9.4",
+    "typescript": "^4.9.5",
     "vite": "^4.0.1",
     "vitest": "^0.28.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7729,10 +7729,15 @@ typedarray-to-buffer@3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.4, typescript@^4.9.4:
+typescript@^4.6.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ufo@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `typescript` to 4.9.5