### PR TITLE
test: enforce exact text match

### DIFF
--- a/components/function/index.test.tsx
+++ b/components/function/index.test.tsx
@@ -29,9 +29,7 @@ describe("Function", () => {
 
       render(<Function address={buildAddress()} func={func} />);
 
-      expect(
-        screen.getByText(stateMutability, { exact: false })
-      ).toBeInTheDocument();
+      expect(screen.getByText(stateMutability)).toBeInTheDocument();
     }
   );
 });

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -44,7 +44,7 @@ describe("Nonpayable", () => {
 
     renderNonpayable({ func });
 
-    expect(screen.getByText(func.name, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(`${func.name} → void`)).toBeInTheDocument();
   });
 
   it("should render function inputs", () => {

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -44,7 +44,7 @@ describe("Payable", () => {
 
     renderPayable({ func });
 
-    expect(screen.getByText(func.name, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(`${func.name} → void`)).toBeInTheDocument();
   });
 
   it("should render function inputs", () => {

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -49,7 +49,7 @@ describe("Pure", () => {
 
     renderPure({ func });
 
-    expect(screen.getByText(func.name, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(`${func.name} → void`)).toBeInTheDocument();
   });
 
   it("should render function inputs", () => {

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -49,7 +49,7 @@ describe("View", () => {
 
     renderView({ func });
 
-    expect(screen.getByText(func.name, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(`${func.name} → void`)).toBeInTheDocument();
   });
 
   it("should render function inputs", () => {


### PR DESCRIPTION
## Motivation

Inexact matchers cause erroneous test failures due to partial matches on generated text.

## Solution

Replace some test assertions that depend on `exact: false`.