### PR TITLE
feat: check verify schema validation

### DIFF
--- a/__tests__/pages/api/verify.test.ts
+++ b/__tests__/pages/api/verify.test.ts
@@ -1,0 +1,52 @@
+import { createMocks } from "node-mocks-http";
+import verifyHandler, { Action } from "pages/api/verify";
+
+describe("handler", () => {
+  it("#check should return an error when guid is not specified", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { action: Action.Check },
+    });
+
+    await verifyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      status: "0",
+      message: "Error",
+      result: `Error: Validation error: Required at "guid"`,
+    });
+  });
+
+  it("#check should return an error when guid is not a string", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { action: Action.Check, guid: 123 },
+    });
+
+    await verifyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      status: "0",
+      message: "Error",
+      result: `Error: Validation error: Expected string, received number at "guid"`,
+    });
+  });
+
+  it("#check should return a success response when guid is valid", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { action: Action.Check, guid: "123" },
+    });
+
+    await verifyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      status: "1",
+      message: "OK",
+      result: "Contract verified! ID: 123",
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@next/font": "^13.1.6",
     "@rainbow-me/rainbowkit": "^0.8.1",
     "ethers": "^5.7.2",
+    "fp-ts": "^2.13.1",
     "lodash": "^4.17.21",
     "lowdb": "5.1.0",
     "next": "^13.1.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "swr": "^2.0.3",
     "wagmi": "^0.11.3",
     "whatwg-fetch": "^3.6.2",
-    "zod": "^3.20.2"
+    "zod": "^3.20.2",
+    "zod-validation-error": "^0.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8280,6 +8280,11 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
+zod-validation-error@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-0.3.1.tgz#c31e5d72ff1e5a682c7eec9901148aefc6981b6d"
+  integrity sha512-3m7VcE4YT3ZdGJoYBZnLt8E1S/r8zPFNDWMc2njaeC7Vxe5FQbgIiwHoerSkli5PgsUyxWQhpFxEAJXkBJvoDg==
+
 zod@^3.20.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,6 +4477,11 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+fp-ts@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.13.1.tgz#1bf2b24136cca154846af16752dc29e8fa506f2a"
+  integrity sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ==
+
 fraction.js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"


### PR DESCRIPTION
## Motivation

Verify check requests with missing/mistyped data payloads should return a 400 status code with helpful error messaging.

## Solution

Add request schema validation to verify check handler.

## Additional Notes

- Add `zod-validation-error`
- Add `fp-ts`