### PR TITLE
deps: upgrade tailwindcss to 3.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-mocks-http": "^1.12.1",
     "postcss": "^8.4.21",
     "prettier": "2.8.4",
-    "tailwindcss": "^3.2.6",
+    "tailwindcss": "^3.2.7",
     "typescript": "^4.9.5",
     "vite": "^4.0.1",
     "vitest": "^0.28.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7627,10 +7627,10 @@ synckit@^0.8.4:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
-tailwindcss@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.6.tgz#9bedbc744a4a85d6120ce0cc3db024c551a5c733"
-  integrity sha512-BfgQWZrtqowOQMC2bwaSNe7xcIjdDEgixWGYOd6AL0CbKHJlvhfdbINeAW76l1sO+1ov/MJ93ODJ9yluRituIw==
+tailwindcss@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.7.tgz#5936dd08c250b05180f0944500c01dce19188c07"
+  integrity sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==
   dependencies:
     arg "^5.0.2"
     chokidar "^3.5.3"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `tailwindcss` to 3.2.7