### PR TITLE
refactor: remove ignore ban types rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
     "vi": true
   },
   "rules": {
-    "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off"
   }

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes, PropsWithChildren } from "react";
 
-type ButtonProps = PropsWithChildren<{}> &
+type ButtonProps = PropsWithChildren<Record<string, any>> &
   ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const Button = ({ children, ...props }: ButtonProps) => {

--- a/components/function/container/index.tsx
+++ b/components/function/container/index.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
 
-type ContainerProps = PropsWithChildren<{}>;
+type ContainerProps = PropsWithChildren<Record<string, any>>;
 
 export const Container = ({ children }: ContainerProps) => {
   return <section className="flex items-center gap-1">{children}</section>;


### PR DESCRIPTION
## Motivation

The `@typescript-eslint/ban-types` lint rule should be enforced.

## Solution

Replace instances of type `{}` with `Record<string, any>`.