### PR TITLE
deps: upgrade next-router-mock to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "husky": "^8.0.3",
     "jsdom": "^21.1.0",
     "msw": "^1.0.1",
-    "next-router-mock": "^0.9.1",
+    "next-router-mock": "^0.9.2",
     "node-mocks-http": "^1.12.1",
     "postcss": "^8.4.21",
     "prettier": "2.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6247,10 +6247,10 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-next-router-mock@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.1.tgz#28adbda2c1bbd0d0b7567e7f83dcf0e211d9a4ba"
-  integrity sha512-GTrns944dnFNgycpinyRszOiwwk99LUJsvvX0FWRgUFHv6hOuzCns1rmTlzO+DRimYB9/XMA+87X2/dQLzjiUQ==
+next-router-mock@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.2.tgz#750341ea0bab9fa04257fb38a85bbe5c25dc19e5"
+  integrity sha512-rh6Mq1xhZ4Y0y9Z3seHZ04k4dAKnAyRcis7q3ZUF+Xp0uBeNqPC8Ydw5DldYncN3o1sYBqRyz25F/v/kfcg0/Q==
 
 next-themes@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `next-router-mock` to 0.9.2