### PR TITLE
refactor: replace empty object with record type

### DIFF
--- a/hooks/useContracts/index.test.tsx
+++ b/hooks/useContracts/index.test.tsx
@@ -6,7 +6,7 @@ import { SWRConfig } from "swr";
 import { PropsWithChildren } from "react";
 import { buildContractDetailsList } from "testing/factory";
 
-const wrapper = ({ children }: PropsWithChildren<{}>) => (
+const wrapper = ({ children }: PropsWithChildren<Record<string, any>>) => (
   <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
 );
 


### PR DESCRIPTION
## Motivation

Remove instances of banned type `{}`.

## Solution

Replace `{}` type with `Record<string, any>`

## Additional Notes

Need to investigate why ESLint isn't identifying this since it is considered a banned type.