### PR TITLE
deps: upgrade zod-validation-error to 1.0.1

### DIFF
--- a/__tests__/pages/api/verify.test.ts
+++ b/__tests__/pages/api/verify.test.ts
@@ -15,13 +15,13 @@ const buildErrorJSONResponse = ({ result }: { result?: string }) => ({
 });
 
 describe("handler", () => {
-  it("#check should return an error when guid is not specified", async () => {
+  it("#check should return an error when guid is not specified", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: { action: Action.Check },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -31,13 +31,13 @@ describe("handler", () => {
     );
   });
 
-  it("#check should return an error when guid is not a string", async () => {
+  it("#check should return an error when guid is not a string", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: { action: Action.Check, guid: 123 },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -47,13 +47,13 @@ describe("handler", () => {
     );
   });
 
-  it("#check should return a success response when guid is valid", async () => {
+  it("#check should return a success response when guid is valid", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: { action: Action.Check, guid: "123" },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(200);
     expect(res._getJSONData()).toEqual(
@@ -63,7 +63,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when contractaddress is not specified", async () => {
+  it("#verify should return an error when contractaddress is not specified", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -74,7 +74,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -84,7 +84,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when contractname is not specified", async () => {
+  it("#verify should return an error when contractname is not specified", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -95,7 +95,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -105,7 +105,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when compilerversion is not specified", async () => {
+  it("#verify should return an error when compilerversion is not specified", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -116,7 +116,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -126,7 +126,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when contractaddress is not a valid address", async () => {
+  it("#verify should return an error when contractaddress is not a valid address", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -138,7 +138,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -148,7 +148,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when contractname is not a string", async () => {
+  it("#verify should return an error when contractname is not a string", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -160,7 +160,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -170,7 +170,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when compilerversion is not a string", async () => {
+  it("#verify should return an error when compilerversion is not a string", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -182,7 +182,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -192,7 +192,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when sourceCode is not specified", async () => {
+  it("#verify should return an error when sourceCode is not specified", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -203,7 +203,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -213,7 +213,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when sourceCode is not a string", async () => {
+  it("#verify should return an error when sourceCode is not a string", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -225,7 +225,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
@@ -235,7 +235,7 @@ describe("handler", () => {
     );
   });
 
-  it("#verify should return an error when contractname is not correctly formatted", async () => {
+  it("#verify should return an error when contractname is not correctly formatted", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
@@ -247,7 +247,7 @@ describe("handler", () => {
       },
     });
 
-    await verifyHandler(req, res);
+    verifyHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(

--- a/__tests__/pages/api/verify.test.ts
+++ b/__tests__/pages/api/verify.test.ts
@@ -26,7 +26,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Required at "guid"`,
+        result: `Validation error: Required at "guid"`,
       })
     );
   });
@@ -42,7 +42,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Expected string, received number at "guid"`,
+        result: `Validation error: Expected string, received number at "guid"`,
       })
     );
   });
@@ -79,7 +79,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Invalid address at "contractaddress"`,
+        result: `Validation error: Invalid address at "contractaddress"`,
       })
     );
   });
@@ -100,7 +100,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Required at "contractname"`,
+        result: `Validation error: Required at "contractname"`,
       })
     );
   });
@@ -121,7 +121,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Required at "compilerversion"`,
+        result: `Validation error: Required at "compilerversion"`,
       })
     );
   });
@@ -143,7 +143,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Invalid address at "contractaddress"`,
+        result: `Validation error: Invalid address at "contractaddress"`,
       })
     );
   });
@@ -165,7 +165,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Expected string, received number at "contractname"`,
+        result: `Validation error: Expected string, received number at "contractname"`,
       })
     );
   });
@@ -187,7 +187,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Expected string, received number at "compilerversion"`,
+        result: `Validation error: Expected string, received number at "compilerversion"`,
       })
     );
   });
@@ -208,7 +208,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Required at "sourceCode"`,
+        result: `Validation error: Required at "sourceCode"`,
       })
     );
   });
@@ -230,7 +230,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Expected string, received number at "sourceCode"`,
+        result: `Validation error: Expected string, received number at "sourceCode"`,
       })
     );
   });
@@ -252,7 +252,7 @@ describe("handler", () => {
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData()).toEqual(
       buildErrorJSONResponse({
-        result: `Error: Validation error: Expected string to match format "path:contractname" at "contractname"`,
+        result: `Validation error: Expected string to match format "path:contractname" at "contractname"`,
       })
     );
   });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wagmi": "^0.11.7",
     "whatwg-fetch": "^3.6.2",
     "zod": "^3.21.0",
-    "zod-validation-error": "^0.3.2"
+    "zod-validation-error": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8539,10 +8539,10 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zod-validation-error@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-0.3.2.tgz#1f09877cd3d671a37d6c0e4e0b7ad42c24d5d8c2"
-  integrity sha512-pBXItXNDup6KF54fdnA+cmB/eEt65HlN5pmahfBTUhufWEnXs4ouU8lLXh01GoAksIR9K7iF7BxXxkKvct+r+A==
+zod-validation-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-1.0.1.tgz#fc8758b667ecdb8121439458c7ab05d0be469b19"
+  integrity sha512-QRk2AtHLJg8sCZAbEjXSs7E0n4/mSdX5caoh6eOUvDSdcIQz03i0xoNN1Qx6UZT+ADVHRK6+ZXRtldzW6nnltA==
 
 zod@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

- Upgrade `zod-validation-error` to 1.0.1
- Update error message assertions to conform with new zod API

## Additional Notes

- Remove erroneous async/await usage in `__tests__/pages/api/verify.test.ts`