### PR TITLE
deps: upgrade typescript to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "postcss": "^8.4.21",
     "prettier": "2.8.4",
     "tailwindcss": "^3.2.7",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.2",
     "vite": "^4.0.1",
     "vitest": "^0.28.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7847,10 +7847,15 @@ typedarray-to-buffer@3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.4, typescript@^4.9.5:
+typescript@^4.6.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 ufo@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `typescript` to 5.0.2