### PR TITLE
refactor: remove function shadow

### DIFF
--- a/components/function/index.test.tsx
+++ b/components/function/index.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "testing";
 import { buildAbiDefinedFunction, buildAddress } from "testing/factory";
 import type { Mock } from "vitest";
 import { useContractRead, useContractWrite } from "wagmi";
-import { Function } from ".";
+import { Func } from ".";
 
 vi.mock("wagmi");
 
@@ -19,7 +19,7 @@ useContractReadMock.mockReturnValue({
 const useContractWriteMock = useContractWrite as Mock;
 useContractWriteMock.mockReturnValue({ write: vi.fn() });
 
-describe("Function", () => {
+describe("Func", () => {
   it.each(["pure", "view", "nonpayable", "payable"] as AbiStateMutability[])(
     "should render a %s function",
     (stateMutability) => {
@@ -27,7 +27,7 @@ describe("Function", () => {
         stateMutability,
       });
 
-      render(<Function address={buildAddress()} func={func} />);
+      render(<Func address={buildAddress()} func={func} />);
 
       expect(screen.getByText(stateMutability)).toBeInTheDocument();
     }

--- a/components/function/index.tsx
+++ b/components/function/index.tsx
@@ -4,12 +4,12 @@ import { Payable } from "./payable";
 import { Pure } from "./pure";
 import { View } from "./view";
 
-type FunctionProps = {
+type FuncProps = {
   address: Address;
   func: AbiDefinedStateFunction;
 };
 
-export const Function = ({ address, func }: FunctionProps) => {
+export const Func = ({ address, func }: FuncProps) => {
   switch (func.stateMutability) {
     case "pure":
       return <Pure address={address} func={func} initialCollapsed={true} />;

--- a/components/functions/index.tsx
+++ b/components/functions/index.tsx
@@ -1,5 +1,5 @@
 import { AbiDefinedStateFunction, Address } from "core/types";
-import { Function } from "components/function";
+import { Func } from "components/function";
 
 type FunctionsProps = {
   address: Address;
@@ -11,11 +11,7 @@ export const Functions = ({ address, functions }: FunctionsProps) => {
   return (
     <ul className="flex flex-col gap-4">
       {functions.map((func) => (
-        <Function
-          key={`${address}-${func.name}`}
-          address={address}
-          func={func}
-        />
+        <Func key={`${address}-${func.name}`} address={address} func={func} />
       ))}
     </ul>
   );


### PR DESCRIPTION
## Motivation

Avoid shadowing the built-in `Function`.

## Solution

Rename `Function` component to `Func`