### PR TITLE
deps: upgrade next-router-mock to 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "husky": "^8.0.3",
     "jsdom": "^21.1.1",
     "msw": "^1.2.1",
-    "next-router-mock": "^0.9.2",
+    "next-router-mock": "^0.9.3",
     "node-mocks-http": "^1.12.2",
     "postcss": "^8.4.21",
     "prettier": "2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6163,10 +6163,10 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-next-router-mock@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.2.tgz#750341ea0bab9fa04257fb38a85bbe5c25dc19e5"
-  integrity sha512-rh6Mq1xhZ4Y0y9Z3seHZ04k4dAKnAyRcis7q3ZUF+Xp0uBeNqPC8Ydw5DldYncN3o1sYBqRyz25F/v/kfcg0/Q==
+next-router-mock@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.3.tgz#8287e96d76d4c7b3720bc9078b148c2b352f1567"
+  integrity sha512-jl8eFe71LpMVGeBMpoxILkGfEgGY7IfLy8XPyv05/o61p5oQRNpoMmk46VMxRIpt0fI8XcvznBZKpDK6vbYQcQ==
 
 next-themes@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `next-router-mock` to 0.9.3