### PR TITLE
📝 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Start the Blacksmith application.
 
 ```bash
 cd blacksmith
-pnpm
+pnpm install
 pnpm dev
 ```
 


### PR DESCRIPTION
fix quick start script

## Motivation

As i was trying to install and use the latest version of blacksmith i found a typo / missing word on the quick start section of the readme.

## Solution

I added the missing command to install the package on pnpm.

## Additional Notes