### PR TITLE
fix(docs): add a install package command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Start the Blacksmith application.
 
 ```bash
 cd blacksmith
-pnpm
+pnpm install
 pnpm dev
 ```
 


### PR DESCRIPTION
## Motivation

When trying to install the latest version of blacksmith I found out that the package installation line was not finished

## Solution

I added the install command to install the packages !

## Additional Notes

@unholypanda 