### PR TITLE
deps: upgrade @faker-js/faker to 8.0.2

### DIFF
--- a/components/field/index.test.tsx
+++ b/components/field/index.test.tsx
@@ -17,41 +17,41 @@ const renderField = (props: PartialProps<typeof Field> = {}) =>
 
 describe("Field", () => {
   it("should render the input name as the label", () => {
-    const inputName = faker.random.word();
+    const inputName = faker.lorem.word();
     renderField({ inputName });
 
     expect(screen.getByLabelText(inputName)).toBeInTheDocument();
   });
 
   it("should render the input type", () => {
-    const type = faker.random.word();
+    const type = faker.lorem.word();
     renderField({ type });
 
     expect(screen.getByText(type)).toBeInTheDocument();
   });
 
   it("should render the input value", () => {
-    const value = faker.random.word();
+    const value = faker.lorem.word();
     renderField({ value });
 
     expect(screen.getByDisplayValue(value)).toBeInTheDocument();
   });
 
   it("should render a disabled input", () => {
-    const inputName = faker.random.word();
+    const inputName = faker.lorem.word();
     renderField({ disabled: true, inputName });
 
     expect(screen.getByLabelText(inputName)).toBeDisabled();
   });
 
   it("should call the handleChange function when the input value changes", async () => {
-    const inputName = faker.random.word();
+    const inputName = faker.lorem.word();
     const handleChange = vi.fn();
 
     const { user } = renderField({ handleChange, inputName });
 
     const input = screen.getByLabelText(inputName);
-    const value = faker.random.word();
+    const value = faker.lorem.word();
 
     await user.type(input, value);
 

--- a/hooks/useArgs/index.test.tsx
+++ b/hooks/useArgs/index.test.tsx
@@ -294,7 +294,7 @@ describe("useArgs", () => {
   });
 
   it("should return provided value when big number conversion throws", () => {
-    const value = faker.random.word();
+    const value = faker.lorem.word();
     const input = buildInput({ type: "uint256" });
     const { result } = renderUseArgsHook([input]);
 
@@ -418,7 +418,7 @@ describe("useArgs", () => {
     const { result } = renderUseArgsHook([input]);
 
     act(() => {
-      result.current.updateValue([0], faker.random.word());
+      result.current.updateValue([0], faker.lorem.word());
     });
 
     expect(result.current.isTouched).toEqual(true);
@@ -429,7 +429,7 @@ describe("useArgs", () => {
     const { result } = renderUseArgsHook(inputs);
 
     act(() => {
-      result.current.updateValue([0], faker.random.word());
+      result.current.updateValue([0], faker.lorem.word());
     });
 
     expect(result.current.isTouched).toEqual(false);

--- a/hooks/useEther/index.test.tsx
+++ b/hooks/useEther/index.test.tsx
@@ -31,7 +31,7 @@ describe("useEther", () => {
 
     act(() => {
       result.current.handleValueChange({
-        target: { value: faker.random.alpha() },
+        target: { value: faker.string.alpha() },
       } as ChangeEvent<HTMLInputElement>);
     });
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.22.1",
     "@commitlint/cli": "^17.6.5",
     "@commitlint/config-conventional": "^17.6.5",
-    "@faker-js/faker": "^7.6.0",
+    "@faker-js/faker": "^8.0.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ devDependencies:
     specifier: ^17.6.5
     version: 17.6.5
   '@faker-js/faker':
-    specifier: ^7.6.0
-    version: 7.6.0
+    specifier: ^8.0.2
+    version: 8.0.2
   '@testing-library/jest-dom':
     specifier: ^5.16.5
     version: 5.16.5
@@ -1130,9 +1130,9 @@ packages:
       '@ethersproject/strings': 5.7.0
     dev: false
 
-  /@faker-js/faker@7.6.0:
-    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
-    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+  /@faker-js/faker@8.0.2:
+    resolution: {integrity: sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
     dev: true
 
   /@headlessui/react@1.7.15(react-dom@18.2.0)(react@18.2.0):

--- a/testing/factory/index.ts
+++ b/testing/factory/index.ts
@@ -17,15 +17,9 @@ import { faker } from "@faker-js/faker/locale/en";
 import capitalize from "lodash/capitalize";
 import times from "lodash/times";
 
-const RESERVED_WORDS = ["value", "void", "unit"];
-
-const { unique } = faker.helpers;
-
-const uniqueOptions = { exclude: RESERVED_WORDS };
-
-const adjective = () => unique(faker.word.adjective, undefined, uniqueOptions);
-const noun = () => unique(faker.word.noun, undefined, uniqueOptions);
-const verb = () => unique(faker.word.verb, undefined, uniqueOptions);
+const adjective = () => faker.word.adjective();
+const noun = () => faker.word.noun();
+const verb = () => faker.word.verb();
 
 const hasProperty = (obj: any, property: string) =>
   Object.prototype.hasOwnProperty.call(obj, property);
@@ -43,7 +37,7 @@ export const buildAbiError = (): AbiError => ({
 });
 
 export const buildAddress = () =>
-  faker.datatype.hexadecimal({ length: 40, case: "lower" }) as Address;
+  faker.string.hexadecimal({ length: 40, casing: "lower" }) as Address;
 
 export const buildContractDetails = (
   overrides: Partial<ContractDetails> = {}
@@ -148,4 +142,4 @@ export const buildOutputList = (n: number): AbiParameter[] =>
 export const buildResult = (value: Result) => value;
 
 export const buildTransactionHash = () =>
-  faker.datatype.hexadecimal({ length: 64, case: "lower" });
+  faker.string.hexadecimal({ length: 64, casing: "lower" });


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `@faker-js/faker` to 8.0.2

## Additional Notes

Removes uniqueness constraint on randomly generated text which may reintroduce test flakiness. This is intentional. The tests should be more robust and not need to depend on uniquely generated text.