### PR TITLE
test: improve performance

### DIFF
--- a/components/field/index.test.tsx
+++ b/components/field/index.test.tsx
@@ -53,7 +53,8 @@ describe("Field", () => {
     const input = screen.getByLabelText(inputName);
     const value = faker.lorem.word();
 
-    await user.type(input, value);
+    await user.click(input);
+    await user.paste(value);
 
     expect(handleChange).toHaveBeenCalled();
   });

--- a/components/function/nonpayable/index.test.tsx
+++ b/components/function/nonpayable/index.test.tsx
@@ -93,10 +93,12 @@ describe("Nonpayable", () => {
     const { user } = renderNonpayable({ address, func });
 
     const firstInput = screen.getByLabelText(func.inputs[0].name!);
-    await user.type(firstInput, "first");
+    await user.click(firstInput);
+    await user.paste("first");
 
     const secondInput = screen.getByLabelText(func.inputs[1].name!);
-    await user.type(secondInput, "second");
+    await user.click(secondInput);
+    await user.paste("second");
 
     await waitFor(() => {
       expect(useContractWriteMock).toHaveBeenCalledWith({

--- a/components/function/payable/index.test.tsx
+++ b/components/function/payable/index.test.tsx
@@ -91,10 +91,12 @@ describe("Payable", () => {
     const { user } = renderPayable({ address, func });
 
     const firstInput = screen.getByLabelText(func.inputs[0].name!);
-    await user.type(firstInput, "first");
+    await user.click(firstInput);
+    await user.paste("first");
 
     const secondInput = screen.getByLabelText(func.inputs[1].name!);
-    await user.type(secondInput, "second");
+    await user.click(secondInput);
+    await user.paste("second");
 
     await waitFor(() => {
       expect(useContractWriteMock).toHaveBeenCalledWith({

--- a/components/function/pure/index.test.tsx
+++ b/components/function/pure/index.test.tsx
@@ -125,10 +125,12 @@ describe("Pure", () => {
     const { user } = renderPure({ address, func });
 
     const firstInput = screen.getByLabelText(func.inputs[0].name!);
-    await user.type(firstInput, "first");
+    await user.click(firstInput);
+    await user.paste("first");
 
     const secondInput = screen.getByLabelText(func.inputs[1].name!);
-    await user.type(secondInput, "second");
+    await user.click(secondInput);
+    await user.paste("second");
 
     await waitFor(() => {
       expect(useContractReadMock).toHaveBeenCalledWith({

--- a/components/function/view/index.test.tsx
+++ b/components/function/view/index.test.tsx
@@ -125,10 +125,12 @@ describe("View", () => {
     const { user } = renderView({ address, func });
 
     const firstInput = screen.getByLabelText(func.inputs[0].name!);
-    await user.type(firstInput, "first");
+    await user.click(firstInput);
+    await user.paste("first");
 
     const secondInput = screen.getByLabelText(func.inputs[1].name!);
-    await user.type(secondInput, "second");
+    await user.click(secondInput);
+    await user.paste("second");
 
     await waitFor(() => {
       expect(useContractReadMock).toHaveBeenCalledWith({

--- a/components/introduction/manager/index.test.tsx
+++ b/components/introduction/manager/index.test.tsx
@@ -15,7 +15,8 @@ describe("Manager", () => {
     const { user } = render(<Manager />);
     const input = screen.getByLabelText("contract address");
 
-    await user.type(input, address);
+    await user.click(input);
+    await user.paste(address);
 
     const button = screen.getByRole("button", { name: "import" });
 
@@ -34,7 +35,8 @@ describe("Manager", () => {
     const { user } = render(<Manager />);
     const input = screen.getByLabelText("contract address");
 
-    await user.type(input, address);
+    await user.click(input);
+    await user.paste(address);
 
     const button = screen.getByRole("button", { name: "import" });
 
@@ -53,7 +55,8 @@ describe("Manager", () => {
     const { user } = render(<Manager />);
     const input = screen.getByLabelText("contract address");
 
-    await user.type(input, address);
+    await user.click(input);
+    await user.paste(address);
 
     const button = screen.getByRole("button", { name: "remove" });
 
@@ -72,7 +75,8 @@ describe("Manager", () => {
     const { user } = render(<Manager />);
     const input = screen.getByLabelText("contract address");
 
-    await user.type(input, address);
+    await user.click(input);
+    await user.paste(address);
 
     const button = screen.getByRole("button", { name: "remove" });
 

--- a/components/introduction/manager/index.tsx
+++ b/components/introduction/manager/index.tsx
@@ -9,6 +9,7 @@ import {
   ButtonHTMLAttributes,
   ChangeEvent,
   DetailedHTMLProps,
+  useCallback,
   useState,
 } from "react";
 
@@ -32,11 +33,14 @@ export const Manager = () => {
   const [address, setAddress] = useState("");
   const { mutate } = useContracts();
 
-  const handleAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setAddress(event.target.value);
-  };
+  const handleAddressChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setAddress(event.target.value);
+    },
+    []
+  );
 
-  const handleImport = () => {
+  const handleImport = useCallback(() => {
     fetch(`/api/contracts/${address}`, {
       method: "POST",
     }).then((response) => {
@@ -46,9 +50,9 @@ export const Manager = () => {
       setResponse(responseMessage);
       mutate();
     });
-  };
+  }, [address, mutate]);
 
-  const handleRemove = () => {
+  const handleRemove = useCallback(() => {
     fetch(`/api/contracts/${address}`, {
       method: "DELETE",
     }).then((response) => {
@@ -58,16 +62,16 @@ export const Manager = () => {
       setResponse(responseMessage);
       mutate();
     });
-  };
+  }, [address, mutate]);
 
-  const handleRemoveAll = () => {
+  const handleRemoveAll = useCallback(() => {
     fetch("/api/contracts", {
       method: "DELETE",
     }).then(() => {
       setDeleteAllResponse("Removed all contracts");
       mutate();
     });
-  };
+  }, [mutate]);
 
   return (
     <div className="flex flex-col">

--- a/components/introduction/setup/index.test.tsx
+++ b/components/introduction/setup/index.test.tsx
@@ -15,7 +15,8 @@ describe("Setup", () => {
     const path = "path/to/contract";
     const { user } = render(<Setup />);
 
-    await user.type(screen.getByLabelText("path"), path);
+    await user.click(screen.getByLabelText("path"));
+    await user.paste(path);
 
     expect(screen.getByText(path, { exact: false })).toBeInTheDocument();
   });
@@ -24,7 +25,8 @@ describe("Setup", () => {
     const contractName = "ContractName";
     const { user } = render(<Setup />);
 
-    await user.type(screen.getByLabelText("contract name"), contractName);
+    await user.click(screen.getByLabelText("contract name"));
+    await user.paste(contractName);
 
     expect(
       screen.getByText(contractName, { exact: false })
@@ -35,7 +37,8 @@ describe("Setup", () => {
     const address = buildAddress();
     const { user } = render(<Setup />);
 
-    await user.type(screen.getByLabelText("deployer address"), address);
+    await user.click(screen.getByLabelText("deployer address"));
+    await user.paste(address);
 
     expect(screen.getByText(address, { exact: false })).toBeInTheDocument();
   });
@@ -44,7 +47,8 @@ describe("Setup", () => {
     const rpcUrl = "http://rpc.url";
     const { user } = render(<Setup />);
 
-    await user.type(screen.getByLabelText("rpc url"), rpcUrl);
+    await user.click(screen.getByLabelText("rpc url"));
+    await user.paste(rpcUrl);
 
     expect(screen.getByText(rpcUrl, { exact: false })).toBeInTheDocument();
   });
@@ -53,7 +57,8 @@ describe("Setup", () => {
     const verifierUrl = "http://verifier.url";
     const { user } = render(<Setup />);
 
-    await user.type(screen.getByLabelText("verifier url"), verifierUrl);
+    await user.click(screen.getByLabelText("verifier url"));
+    await user.paste(verifierUrl);
 
     expect(screen.getByText(verifierUrl, { exact: false })).toBeInTheDocument();
   });

--- a/components/wallet/transfer/index.test.tsx
+++ b/components/wallet/transfer/index.test.tsx
@@ -50,7 +50,7 @@ describe("Transfer", () => {
   });
 
   it("should allow user to change value", async () => {
-    const value = faker.random.numeric(3);
+    const value = faker.string.numeric(3);
     const { user } = renderTransfer();
 
     const valueInput = screen.getByLabelText("value");

--- a/components/wallet/transfer/index.test.tsx
+++ b/components/wallet/transfer/index.test.tsx
@@ -43,7 +43,8 @@ describe("Transfer", () => {
 
     const recipientInput = screen.getByLabelText("recipient");
 
-    await user.type(recipientInput, address);
+    await user.click(recipientInput);
+    await user.paste(address);
 
     expect(recipientInput).toHaveValue(address);
   });


### PR DESCRIPTION
## Motivation

<!-- Describe why this change is being proposed. -->

## Solution

- Use userEvent `click` and `paste` rather than `type` for long inputs.
- Wraps `Manager` component functions in `useCallback`.

## Additional Notes

- Replace deprecated `faker` helper.