### PR TITLE
deps: upgrade next-router-mock to 0.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "husky": "^8.0.3",
     "jsdom": "^22.1.0",
     "msw": "^1.2.1",
-    "next-router-mock": "^0.9.3",
+    "next-router-mock": "^0.9.6",
     "node-mocks-http": "^1.12.2",
     "postcss": "^8.4.24",
     "prettier": "2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ devDependencies:
     specifier: ^1.2.1
     version: 1.2.1(typescript@5.1.3)
   next-router-mock:
-    specifier: ^0.9.3
-    version: 0.9.3(next@13.4.4)(react@18.2.0)
+    specifier: ^0.9.6
+    version: 0.9.6(next@13.4.4)(react@18.2.0)
   node-mocks-http:
     specifier: ^1.12.2
     version: 1.12.2
@@ -6058,8 +6058,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /next-router-mock@0.9.3(next@13.4.4)(react@18.2.0):
-    resolution: {integrity: sha512-jl8eFe71LpMVGeBMpoxILkGfEgGY7IfLy8XPyv05/o61p5oQRNpoMmk46VMxRIpt0fI8XcvznBZKpDK6vbYQcQ==}
+  /next-router-mock@0.9.6(next@13.4.4)(react@18.2.0):
+    resolution: {integrity: sha512-ezX+4ZlnVPi63/wjvJ5Cnf+0k/H6VdjAitRs+UX+6rzOfuRLC6q72clAa43xIwBkAV3uHxWqzE9CK5S8h1c7tg==}
     peerDependencies:
       next: '>=10.0.0'
       react: '>=17.0.0'


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `next-router-mock` to 0.9.6