### PR TITLE
deps: upgrade next-router-mock to 0.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "husky": "^8.0.3",
     "jsdom": "^22.1.0",
     "msw": "^1.2.2",
-    "next-router-mock": "^0.9.6",
+    "next-router-mock": "^0.9.7",
     "node-mocks-http": "^1.12.2",
     "postcss": "^8.4.24",
     "prettier": "2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ devDependencies:
     specifier: ^1.2.2
     version: 1.2.2(typescript@5.1.3)
   next-router-mock:
-    specifier: ^0.9.6
-    version: 0.9.6(next@13.4.6)(react@18.2.0)
+    specifier: ^0.9.7
+    version: 0.9.7(next@13.4.6)(react@18.2.0)
   node-mocks-http:
     specifier: ^1.12.2
     version: 1.12.2
@@ -6162,8 +6162,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /next-router-mock@0.9.6(next@13.4.6)(react@18.2.0):
-    resolution: {integrity: sha512-ezX+4ZlnVPi63/wjvJ5Cnf+0k/H6VdjAitRs+UX+6rzOfuRLC6q72clAa43xIwBkAV3uHxWqzE9CK5S8h1c7tg==}
+  /next-router-mock@0.9.7(next@13.4.6)(react@18.2.0):
+    resolution: {integrity: sha512-y5ioLCIsdkJKwcoPnrUyocNEJT22RK4wKSg6LO0Q2XkBBvkYprEWy5FiCZt+CA8+qpfxpBlNca76F+glEohbRA==}
     peerDependencies:
       next: '>=10.0.0'
       react: '>=17.0.0'


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `next-router-mock` to 0.9.7