### PR TITLE
deps: upgrade eslint-config-prettier to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "autoprefixer": "^10.4.14",
     "eslint": "^8.46.0",
     "eslint-config-next": "^13.4.10",
-    "eslint-config-prettier": "^8.9.0",
+    "eslint-config-prettier": "^9.0.0",
     "husky": "^8.0.3",
     "jsdom": "^22.1.0",
     "msw": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ devDependencies:
     specifier: ^13.4.10
     version: 13.4.10(eslint@8.46.0)(typescript@5.1.6)
   eslint-config-prettier:
-    specifier: ^8.9.0
-    version: 8.9.0(eslint@8.46.0)
+    specifier: ^9.0.0
+    version: 9.0.0(eslint@8.46.0)
   husky:
     specifier: ^8.0.3
     version: 8.0.3
@@ -4119,8 +4119,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-prettier@8.9.0(eslint@8.46.0):
-    resolution: {integrity: sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==}
+  /eslint-config-prettier@9.0.0(eslint@8.46.0):
+    resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `eslint-config-prettier` to 9.0.0