### PR TITLE
deps: upgrade whatwg-fetch to 3.6.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "swr": "^2.2.2",
     "viem": "^1.10.7",
     "wagmi": "^1.3.10",
-    "whatwg-fetch": "^3.6.17",
+    "whatwg-fetch": "^3.6.18",
     "zod": "^3.21.4",
     "zod-validation-error": "^1.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: ^1.3.10
     version: 1.3.10(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(viem@1.10.7)(zod@3.21.4)
   whatwg-fetch:
-    specifier: ^3.6.17
-    version: 3.6.17
+    specifier: ^3.6.18
+    version: 3.6.18
   zod:
     specifier: ^3.21.4
     version: 3.21.4
@@ -7979,8 +7979,8 @@ packages:
       iconv-lite: 0.6.3
     dev: true
 
-  /whatwg-fetch@3.6.17:
-    resolution: {integrity: sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==}
+  /whatwg-fetch@3.6.18:
+    resolution: {integrity: sha512-ltN7j66EneWn5TFDO4L9inYC1D+Czsxlrw2SalgjMmEMkLfA5SIZxEFdE6QtHFiiM6Q7WL32c7AkI3w6yxM84Q==}
     dev: false
 
   /whatwg-mimetype@3.0.0:


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `whatwg-fetch` to 3.6.18