### PR TITLE
deps: upgrade next-router-mock to 0.9.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "husky": "^8.0.3",
     "jsdom": "^22.1.0",
     "msw": "^1.3.2",
-    "next-router-mock": "^0.9.9",
+    "next-router-mock": "^0.9.10",
     "node-mocks-http": "^1.13.0",
     "postcss": "^8.4.31",
     "prettier": "3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ devDependencies:
     specifier: ^1.3.2
     version: 1.3.2(typescript@5.2.2)
   next-router-mock:
-    specifier: ^0.9.9
-    version: 0.9.9(next@13.4.19)(react@18.2.0)
+    specifier: ^0.9.10
+    version: 0.9.10(next@13.4.19)(react@18.2.0)
   node-mocks-http:
     specifier: ^1.13.0
     version: 1.13.0
@@ -5835,8 +5835,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /next-router-mock@0.9.9(next@13.4.19)(react@18.2.0):
-    resolution: {integrity: sha512-2o50zr+5pWj0zzcvBEWNHDlmWmlDExPdX5OuXKW2aCxV85XUA6MlELr0n0f0wtXj5dUVZ8qspHj6YwF7KZHrbA==}
+  /next-router-mock@0.9.10(next@13.4.19)(react@18.2.0):
+    resolution: {integrity: sha512-bK6sRb/xGNFgHVUZuvuApn6KJBAKTPiP36A7a9mO77U4xQO5ukJx9WHlU67Tv8AuySd09pk0+Hu8qMVIAmLO6A==}
     peerDependencies:
       next: '>=10.0.0'
       react: '>=17.0.0'


### PR DESCRIPTION
## Motivation

Keep dependencies updated.

## Solution

Upgrade `next-router-mock` to 0.9.10